### PR TITLE
Feature/add support for new coordinates format

### DIFF
--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -63,7 +63,6 @@ export function renderFieldElement(fieldTitle, fieldValue, options) {
         fieldElement.classList.add("inline");
     }
     const fieldValueElement = renderFieldValueElement(fieldValue);
-    console.log("renderFieldElement", fieldValueElement);
     if (fieldTitle?.length) {
         fieldValueElement.classList.add("has-title");
     }

--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -15,13 +15,23 @@ function renderFieldTitleElement(fieldTitle, inline) {
 }
 
 /**
- * Creates a span element and sets its inner HTML to the provided field value.
+ * Renders a field value as a span element, formatting arrays and objects for display.
  *
- * @param {string} fieldValue - The value to be displayed inside the span element.
- * @returns {HTMLElement} The span element containing the field value.
+ * - Arrays are joined into a comma-separated string.
+ * - Objects are stringified as pretty-printed JSON.
+ * - If the value is falsy or empty, the span will be empty.
+ *
+ * @param {*} fieldValue - The value to render. Can be of any type (string, number, array, object, etc.).
+ * @returns {HTMLSpanElement} A span element containing the formatted field value.
  */
 function renderFieldValueElement(fieldValue) {
     const fieldValueElement = document.createElement("span");
+    if (Array.isArray(fieldValue)) {
+        fieldValue = fieldValue.join(", ");
+    }
+    if (typeof fieldValue === "object") {
+        fieldValue = JSON.stringify(fieldValue, null, 2);
+    }
     fieldValueElement.innerHTML = hasValue(fieldValue) ? fieldValue : "";
     return fieldValueElement;
 }
@@ -53,6 +63,7 @@ export function renderFieldElement(fieldTitle, fieldValue, options) {
         fieldElement.classList.add("inline");
     }
     const fieldValueElement = renderFieldValueElement(fieldValue);
+    console.log("renderFieldElement", fieldValueElement);
     if (fieldTitle?.length) {
         fieldValueElement.classList.add("has-title");
     }

--- a/src/components/layout-components/dispensasjon/renderers.js
+++ b/src/components/layout-components/dispensasjon/renderers.js
@@ -415,7 +415,7 @@ export function renderStedfestingPosisjonKoordinatsystem(dispensasjon, textResou
  */
 export function renderStedfestingPosisjonKoordinater(dispensasjon, textResources, textResourceBindings) {
     const htmlAttributes = new CustomElementHtmlAttributes({
-        formData: { simpleBinding: dispensasjon?.stedfesting?.posisjon?.koordinater },
+        formData: { simpleBinding: dispensasjon?.stedfesting?.posisjon?.koordinater?.koordinat },
         text: getTextResourceFromResourceBinding(textResources, textResourceBindings?.stedfestingPosisjonKoordinater?.title),
         hideIfEmpty: true
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2731,16 +2731,16 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.0.0, browserslist@npm:^4.24.0, browserslist@npm:^4.24.5, browserslist@npm:^4.25.0":
-  version: 4.25.0
-  resolution: "browserslist@npm:4.25.0"
+  version: 4.25.1
+  resolution: "browserslist@npm:4.25.1"
   dependencies:
-    caniuse-lite: "npm:^1.0.30001718"
-    electron-to-chromium: "npm:^1.5.160"
+    caniuse-lite: "npm:^1.0.30001726"
+    electron-to-chromium: "npm:^1.5.173"
     node-releases: "npm:^2.0.19"
     update-browserslist-db: "npm:^1.1.3"
   bin:
     browserslist: cli.js
-  checksum: 10c0/cc16c55b4468b18684a0e1ca303592b38635b1155d6724f172407192737a2f405b8030d87a05813729592793445b3d15e737b0055f901cdecccb29b1e580a1c5
+  checksum: 10c0/acba5f0bdbd5e72dafae1e6ec79235b7bad305ed104e082ed07c34c38c7cb8ea1bc0f6be1496958c40482e40166084458fc3aee15111f15faa79212ad9081b2a
   languageName: node
   linkType: hard
 
@@ -2849,7 +2849,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001718":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001726":
   version: 1.0.30001726
   resolution: "caniuse-lite@npm:1.0.30001726"
   checksum: 10c0/2c5f91da7fd9ebf8c6b432818b1498ea28aca8de22b30dafabe2a2a6da1e014f10e67e14f8e68e872a0867b6b4cd6001558dde04e3ab9770c9252ca5c8849d0e
@@ -3587,10 +3587,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.160":
-  version: 1.5.173
-  resolution: "electron-to-chromium@npm:1.5.173"
-  checksum: 10c0/3242129332438ddc34c30dc218241e837fd87e8db54ba5d22a2e3e789115ce15932b5989d91b14be304081446a4c169bc1e573db6edd6eb3e859a7dba44e6c0a
+"electron-to-chromium@npm:^1.5.173":
+  version: 1.5.176
+  resolution: "electron-to-chromium@npm:1.5.176"
+  checksum: 10c0/ab591218086d6f73d2f773756f7d277a1d176a6b83d6499864d2bc305b1ea1c7673c30f8541d0c55d40fb7f2595fe4041e72aa07351275ba04862b9bc507cc66
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Formats field values and corrects path to `koordinat`.

This pull request enhances the display of field values by formatting arrays and objects and fixes an incorrect path to the `koordinat` value within the `dispensasjon` data structure. It also updates node dependencies in `yarn.lock`.

### Changes

- `src/components/base-components/custom-field/renderers.js`: The `renderFieldValueElement` function is modified to format arrays (joined with ", ") and objects (pretty-printed JSON) for display. Falsy or empty values now render as an empty span.
- `src/components/layout-components/dispensasjon/renderers.js`: The `renderStedfestingPosisjonKoordinater` function is updated to access the `koordinat` value at the correct path `dispensasjon?.stedfesting?.posisjon?.koordinater?.koordinat`.
- `yarn.lock`: Node dependencies are updated, including `browserslist`, `caniuse-lite`, and `electron-to-chromium`.

### Impact

- **Behavioral changes**: Arrays and objects will now be displayed in a user-friendly format. The `koordinat` value will now be correctly displayed.
- **Dependencies affected**: Several node dependencies have been updated which could affect the build or runtime behavior.
