### PR TITLE
Hotfix/add missing form data migrations

### DIFF
--- a/src/components/layout-components/dispensasjon/renderers.js
+++ b/src/components/layout-components/dispensasjon/renderers.js
@@ -277,13 +277,14 @@ export function renderInngangsbeskrivelse(component) {
     }
     const condition = data?.soeknadstype?.kodebeskrivelse === "Annet";
     const htmlAttributes = new CustomElementHtmlAttributes({
-        formData: {
-            simpleBinding: condition,
+        isChildComponent: true,
+        hideIfEmpty: false,
+        resourceValues: {
+            data: condition,
             trueData: data?.dispensasjonBeskrivelse?.annenInngangsbeskrivelse,
             falseData: data?.dispensasjonBeskrivelse?.inngangsbeskrivelse?.kodebeskrivelse,
             defaultData: data?.dispensasjonBeskrivelse?.inngangsbeskrivelse?.kodebeskrivelse
-        },
-        hideIfEmpty: true
+        }
     });
     return addContainerElement(createCustomElement("custom-field-boolean-data", htmlAttributes));
 }

--- a/src/components/layout-components/dispensasjon/renderers.js
+++ b/src/components/layout-components/dispensasjon/renderers.js
@@ -576,7 +576,6 @@ export function renderOensketVarighet(component) {
     } else if (hasValue(data?.varighet?.oensketVarighetTil)) {
         const htmlAttributes = new CustomElementHtmlAttributes({
             isChildComponent: true,
-            formData: { simpleBinding: dispensasjon?.varighet?.oensketVarighetTil },
             format: "date",
             resourceBindings: {
                 title: component.resourceBindings?.varighetOensketVarighetTil?.title


### PR DESCRIPTION
Refactor: Replace `formData` with `resourceValues` in inngangsbeskrivelse.

This release replaces the `formData` prop with `resourceValues` in the `renderInngangsbeskrivelse` function within `renderers.js`. This refactoring aims to improve data handling and component configuration by utilizing a more structured approach to passing data to the custom element.

### Changes

- Replaced the `formData` prop with `resourceValues` prop in `CustomElementHtmlAttributes` within the `renderInngangsbeskrivelse` function.
- Modified data structure for passing data to the `custom-field-boolean-data` element, switching from `simpleBinding`, `trueData`, `falseData`, `defaultData` keys under `formData` to `data`, `trueData`, `falseData`, `defaultData` under `resourceValues`.
- Added `isChildComponent: true` and `hideIfEmpty: false` in `CustomElementHtmlAttributes`.
- Modified the data value within `resourceValues` to reflect the condition `data?.soeknadstype?.kodebeskrivelse === "Annet"`.
- Modified `src/components/layout-components/dispensasjon/renderers.js`.

### Impact

- **Behavioral change**: The `custom-field-boolean-data` component will now receive data through the `resourceValues` prop instead of `formData`.
- **Dependencies affected**: The `custom-field-boolean-data` component needs to be compatible with the new `resourceValues` structure.
- **Updates**: The logic handling inngangsbeskrivelse is updated to align with the new data structure.
