### PR TITLE
Hotfix/fix missing string formatter

### DIFF
--- a/src/classes/system-classes/component-classes/CustomFieldData.js
+++ b/src/classes/system-classes/component-classes/CustomFieldData.js
@@ -3,6 +3,7 @@ import CustomComponent from "../CustomComponent.js";
 
 // Global functions
 import { getComponentDataValue, getComponentResourceValue, hasValue } from "../../../functions/helpers.js";
+import { formatString } from "../../../functions/dataFormatHelpers.js";
 
 /**
  * CustomFieldData is a class that extends CustomComponent to handle custom field data logic.
@@ -46,12 +47,13 @@ export default class CustomFieldData extends CustomComponent {
     }
 
     /**
-     * Retrieves the value of the component from the provided form data properties.
+     * Retrieves and formats the value from the provided form data props.
      *
-     * @param {Object} props - The properties containing form data for the component.
-     * @returns {*} The value extracted from the form data for the component.
+     * @param {Object} props - The properties containing form data and formatting options.
+     * @returns {string} The formatted value extracted from the form data.
      */
     getValueFromFormData(props) {
-        return getComponentDataValue(props);
+        const data = getComponentDataValue(props);
+        return formatString(data, props?.format);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7942,8 +7942,8 @@ __metadata:
   linkType: hard
 
 "webpack@npm:^5.97.1":
-  version: 5.100.0
-  resolution: "webpack@npm:5.100.0"
+  version: 5.100.1
+  resolution: "webpack@npm:5.100.1"
   dependencies:
     "@types/eslint-scope": "npm:^3.7.7"
     "@types/estree": "npm:^1.0.8"
@@ -7975,7 +7975,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10c0/65e93807985a469b683b6a089e994a3b61c64aa67fa60b4322f6e857cc9b3312080ba1f29041aacb5d382bd16bea1ab6384e149034cdd71ee138a17df295860a
+  checksum: 10c0/6dd8e286a5e361650c543dc6c4922b82276b0ed57ae545014bf4f6486d857d1c388dc8ec798f1dc3b77a765936357286910879fab65e6ff53e4cba1cc13db538
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Formats custom field data.

This pull request introduces formatting to custom field data values retrieved from form data. It utilizes a new `formatString` function to apply specified formatting options.

### Changes

- Modified `getValueFromFormData` in `src/classes/system-classes/component-classes/CustomFieldData.js` to use `formatString`.
- The `getValueFromFormData` method now takes the data retrieved using `getComponentDataValue` and formats it using the `formatString` function, passing in the data and the `format` property from the `props` object.

### Impact

- Custom field data values will now be formatted based on the provided format string.
- The behavior of `getValueFromFormData` has changed to include formatting.
