### PR TITLE
Enhances custom table components with resource binding

### DIFF
--- a/src/classes/system-classes/component-classes/CustomTableEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomTableEiendom.js
@@ -7,38 +7,36 @@ import { getComponentDataValue, getTextResourceFromResourceBinding, hasValue } f
 import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
 /**
- * CustomTableEiendom is a custom component class for handling and displaying a list of "eiendom" (property) objects.
- * It provides utility methods for extracting, validating, and formatting property data from form input,
- * as well as for retrieving localized text resources and validation messages.
+ * CustomTableEiendom is a specialized component class for handling and displaying
+ * property ("eiendom") data in a custom table format. It provides methods for extracting,
+ * validating, and binding text resources to property fields, as well as utility functions
+ * for checking the presence and validity of property-related data.
  *
- * @class
  * @extends CustomComponent
  *
- * @param {Object} props - The properties containing form data, resource bindings, and component information.
+ * @class
+ * @param {Object} props - The properties for the component, including form data and resource bindings.
  *
- * @property {boolean} isEmpty - Indicates if the component's data is empty.
- * @property {boolean} validationMessages - Indicates if there are missing text resources for validation.
- * @property {boolean} hasValidationMessages - Indicates if there are any validation messages.
- * @property {Object} resourceValues - Contains localized text resources for the component.
- * @property {string} resourceValues.title - The localized title for the component.
- * @property {string|Array} resourceValues.data - The localized empty field text or the data array.
- *
+ * @property {boolean} isEmpty - Indicates if the property data is empty.
+ * @property {boolean} hasValidationMessages - Indicates if there are missing text resources for validation.
+ * @property {Object} validationMessages - Validation messages based on text resource bindings.
+ * @property {Object} resourceBindings - Text resource bindings for property fields.
+ * @property {Object} resourceValues - Resolved text resources for display, including empty field text.
  */
 export default class CustomTableEiendom extends CustomComponent {
     constructor(props) {
         super(props);
         const data = this.getValueFromFormData(props);
-        const textResourceBindings = this.getTextResourceBindings();
+        const resourceBindings = this.getTextResourceBindings(props);
 
         const isEmpty = !this.hasContent(data);
-        const validationMessages = this.getValidationMessages(textResourceBindings);
+        const validationMessages = this.getValidationMessages(resourceBindings);
 
         this.isEmpty = isEmpty;
         this.validationMessages = validationMessages;
         this.hasValidationMessages = hasValidationMessages(validationMessages);
-
+        this.resourceBindings = resourceBindings;
         this.resourceValues = {
-            title: getTextResourceFromResourceBinding(textResourceBindings?.part?.title),
             data: isEmpty ? getTextResourceFromResourceBinding(props?.resourceBindings?.emptyFieldText) : data
         };
     }
@@ -173,17 +171,77 @@ export default class CustomTableEiendom extends CustomComponent {
     }
 
     /**
-     * Returns the text resource bindings for the component.
+     * Generates an object containing text resource bindings for various property fields.
+     * The bindings are determined by the provided `props` object, falling back to default resource keys if not specified.
      *
-     * @returns {Object} An object containing text resource keys for localization.
-     * @returns {Object} return.eiendomByggested - Bindings related to 'eiendomByggested'.
-     * @returns {string} return.eiendomByggested.title - The resource key for the 'eiendom' title.
+     * @param {Object} props - The properties object containing resource bindings and configuration flags.
+     * @param {Object} [props.resourceBindings] - Custom resource bindings for each field.
+     * @param {Object} [props.resourceBindings.adresse] - Resource bindings for the address field.
+     * @param {string} [props.resourceBindings.adresse.title] - Custom title for the address field.
+     * @param {string} [props.resourceBindings.adresse.emptyFieldText] - Custom empty field text for the address field.
+     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon] - Resource bindings for property identification fields.
+     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.gaardsnummer] - Resource bindings for gaardsnummer.
+     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.gaardsnummer.title] - Custom title for gaardsnummer.
+     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.bruksnummer] - Resource bindings for bruksnummer.
+     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.bruksnummer.title] - Custom title for bruksnummer.
+     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.seksjonsnummer] - Resource bindings for seksjonsnummer.
+     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.seksjonsnummer.title] - Custom title for seksjonsnummer.
+     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.festenummer] - Resource bindings for festenummer.
+     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.festenummer.title] - Custom title for festenummer.
+     * @param {Object} [props.resourceBindings.bolignummer] - Resource bindings for bolignummer.
+     * @param {string} [props.resourceBindings.bolignummer.title] - Custom title for bolignummer.
+     * @param {Object} [props.resourceBindings.bygningsnummer] - Resource bindings for bygningsnummer.
+     * @param {string} [props.resourceBindings.bygningsnummer.title] - Custom title for bygningsnummer.
+     * @param {string} [props.resourceBindings.title] - Custom title for eiendomByggested.
+     * @param {string} [props.resourceBindings.emptyFieldText] - Custom empty field text for eiendomByggested.
+     * @param {boolean|string} [props.hideTitle] - If true or "true", omits the eiendomByggested title binding.
+     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", omits the eiendomByggested empty field text binding.
+     * @returns {Object} An object containing the resolved text resource bindings for each field.
      */
-    getTextResourceBindings() {
-        return {
-            eiendomByggested: {
-                title: "resource.eiendomByggested.eiendom.title"
+    getTextResourceBindings(props) {
+        const resourceBindings = {
+            adresse: {
+                title: props?.resourceBindings?.adresse?.title || "resource.eiendomByggested.eiendom.adresse.title",
+                emptyFieldText: props?.resourceBindings?.adresse?.emptyFieldText || "resource.eiendomByggested.eiendom.adresse.emptyFieldText"
+            },
+            eiendomsidentifikasjonGaardsnummer: {
+                title:
+                    props?.resourceBindings?.eiendomsidentifikasjon?.gaardsnummer?.title ||
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.gaardsnummer.title"
+            },
+            eiendomsidentifikasjonBruksnummer: {
+                title:
+                    props?.resourceBindings?.eiendomsidentifikasjon?.bruksnummer?.title ||
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.bruksnummer.title"
+            },
+            eiendomsidentifikasjonSeksjonsnummer: {
+                title:
+                    props?.resourceBindings?.eiendomsidentifikasjon?.seksjonsnummer?.title ||
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.seksjonsnummer.title"
+            },
+            eiendomsidentifikasjonFestenummer: {
+                title:
+                    props?.resourceBindings?.eiendomsidentifikasjon?.festenummer?.title ||
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.festenummer.title"
+            },
+            bolignummer: {
+                title: props?.resourceBindings?.bolignummer?.title || "resource.eiendomByggested.eiendom.bolignummer.title"
+            },
+            bygningsnummer: {
+                title: props?.resourceBindings?.bygningsnummer?.title || "resource.eiendomByggested.eiendom.bygningsnummer.title"
             }
         };
+        if (!props?.hideTitle === true || !props?.hideTitle === "true") {
+            resourceBindings.eiendomByggested = {
+                title: props?.resourceBindings?.title || "resource.eiendomByggested.eiendom.title"
+            };
+        }
+        if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
+            resourceBindings.eiendomByggested = {
+                ...resourceBindings.eiendomByggested,
+                emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"
+            };
+        }
+        return resourceBindings;
     }
 }

--- a/src/classes/system-classes/component-classes/CustomTablePart.js
+++ b/src/classes/system-classes/component-classes/CustomTablePart.js
@@ -7,40 +7,33 @@ import { getComponentDataValue, getTextResourceFromResourceBinding, hasValue } f
 import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
 /**
- * CustomTablePart is a custom component class for handling table parts in a form.
- * It manages resource bindings, validation messages, and content checks for a specific part type.
+ * CustomTablePart is a specialized component class for handling custom table parts in a form.
+ * It provides methods for extracting and validating part data, generating text resource bindings,
+ * and determining the presence of content and validation messages.
  *
  * @extends CustomComponent
  *
- * @param {Object} props - The properties object for the component.
- * @param {string} [props.partType] - The type of the part.
- * @param {Object} [props.resourceBindings] - Resource bindings for the component.
- * @param {Object} [props.formData] - Form data for the component.
- *
- * @property {boolean} isEmpty - Indicates if the component has content.
- * @property {string} partType - The type of the part.
- * @property {boolean} validationMessages - Validation messages for the component.
- * @property {boolean} hasValidationMessages - Indicates if there are validation messages.
- * @property {Object} resourceValues - Contains resource values for title and data.
- *
  * @class
+ * @param {Object} props - The properties for the component.
+ * @param {string} [props.partType] - The type of part, used for resource key generation.
+ * @param {Object} [props.resourceBindings] - Optional custom resource bindings for fields.
+ * @param {Object} [props.formData] - The form data object.
  */
 export default class CustomTablePart extends CustomComponent {
     constructor(props) {
         super(props);
         const data = this.getValueFromFormData(props);
-        const textResourceBindings = this.getTextResourceBindings(props.partType);
+        const resourceBindings = this.getTextResourceBindings(props);
 
         const isEmpty = !this.hasContent(data);
-        const validationMessages = this.getValidationMessages(textResourceBindings);
+        const validationMessages = this.getValidationMessages(resourceBindings);
 
         this.isEmpty = isEmpty;
         this.partType = props?.partType;
         this.validationMessages = validationMessages;
         this.hasValidationMessages = hasValidationMessages(validationMessages);
-
+        this.resourceBindings = resourceBindings;
         this.resourceValues = {
-            title: getTextResourceFromResourceBinding(textResourceBindings?.part?.title),
             data: isEmpty ? getTextResourceFromResourceBinding(props?.resourceBindings?.emptyFieldText) : data
         };
     }
@@ -141,16 +134,47 @@ export default class CustomTablePart extends CustomComponent {
     }
 
     /**
-     * Generates text resource bindings for a given part type.
+     * Generates text resource bindings for a custom table part component.
      *
-     * @param {string} [partType="tiltakshaver"] - The type of part to generate resource keys for.
-     * @returns {Object} An object containing resource key mappings for the specified part type.
+     * @param {Object} props - The properties for the component.
+     * @param {string} [props.partType="tiltakshaver"] - The type of part, used for resource key generation.
+     * @param {Object} [props.resourceBindings] - Optional custom resource bindings for fields.
+     * @param {Object} [props.resourceBindings.navn] - Resource bindings for the "navn" field.
+     * @param {string} [props.resourceBindings.navn.title] - Custom title for the "navn" field.
+     * @param {Object} [props.resourceBindings.telefonnummer] - Resource bindings for the "telefonnummer" field.
+     * @param {string} [props.resourceBindings.telefonnummer.title] - Custom title for the "telefonnummer" field.
+     * @param {Object} [props.resourceBindings.epost] - Resource bindings for the "epost" field.
+     * @param {string} [props.resourceBindings.epost.title] - Custom title for the "epost" field.
+     * @param {string} [props.resourceBindings.title] - Custom title for the part header.
+     * @param {string} [props.resourceBindings.emptyFieldText] - Custom text for empty fields.
+     * @param {boolean|string} [props.hideTitle] - If true, hides the part title.
+     * @param {boolean|string} [props.hideIfEmpty] - If true, hides the empty field text.
+     * @returns {Object} Resource bindings object for use in the component.
      */
-    getTextResourceBindings(partType = "tiltakshaver") {
-        return {
-            part: {
-                title: `resource.${partType}.header`
+    getTextResourceBindings(props) {
+        const partType = props?.partType || "tiltakshaver";
+        const resourceBindings = {
+            navn: {
+                title: props?.resourceBindings?.navn?.title || `resource.${partType}.navn.title`
+            },
+            telefonnummer: {
+                title: props?.resourceBindings?.telefonnummer?.title || `resource.${partType}.telefonnummer.title`
+            },
+            epost: {
+                title: props?.resourceBindings?.epost?.title || `resource.${partType}.epost.title`
             }
         };
+        if (!props?.hideTitle === true || !props?.hideTitle === "true") {
+            resourceBindings.part = {
+                title: props?.resourceBindings?.title || `resource.${partType}.header`
+            };
+        }
+        if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
+            resourceBindings.part = {
+                ...resourceBindings.part,
+                emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"
+            };
+        }
+        return resourceBindings;
     }
 }

--- a/src/components/data-components/custom-table-eiendom/renderers.js
+++ b/src/components/data-components/custom-table-eiendom/renderers.js
@@ -7,10 +7,14 @@ import { createCustomElement } from "../../../functions/helpers.js";
 /**
  * Renders a custom table element for displaying property (eiendom) data.
  *
- * @param {Object} component - The component configuration object.
- * @param {Object} [component.formData] - The form data to populate the table.
- * @param {Object} [component.texts] - The text resources for localization.
- * @returns {HTMLElement} The custom table element representing the property data.
+ * The table includes columns for address, property identification numbers (gaardsnummer, bruksnummer, seksjonsnummer, festenummer),
+ * housing number (bolignummer), and building number (bygningsnummer). Each column uses resource bindings for titles and empty field text,
+ * and some columns allow style overrides.
+ *
+ * @param {Object} component - The component configuration object containing resource bindings and values.
+ * @param {Object} [component.resourceBindings] - Resource bindings for column titles and empty field text.
+ * @param {Object} [component.resourceValues] - Resource values for the table.
+ * @returns {HTMLElement} The rendered custom table element.
  */
 export function renderEiendomTable(component) {
     const tableColumns = [
@@ -18,8 +22,8 @@ export function renderEiendomTable(component) {
             dataKey: "adresse",
             tagName: "custom-field-adresse",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.adresse.title",
-                emptyFieldText: "resource.eiendomByggested.eiendom.adresse.emptyFieldText"
+                title: component?.resourceBindings?.adresse?.title,
+                emptyFieldText: component?.resourceBindings?.adresse?.emptyFieldText
             },
             props: {
                 styleOverride: {
@@ -31,50 +35,48 @@ export function renderEiendomTable(component) {
             dataKey: "eiendomsidentifikasjon.gaardsnummer",
             tagName: "custom-field-data",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.gaardsnummer.title",
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.eiendomsidentifikasjonGaardsnummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
             dataKey: "eiendomsidentifikasjon.bruksnummer",
             tagName: "custom-field-data",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.bruksnummer.title",
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.eiendomsidentifikasjonBruksnummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
             dataKey: "eiendomsidentifikasjon.seksjonsnummer",
             tagName: "custom-field-data",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.seksjonsnummer.title",
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.eiendomsidentifikasjonSeksjonsnummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
             dataKey: "eiendomsidentifikasjon.festenummer",
             tagName: "custom-field-data",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.festenummer.title",
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.eiendomsidentifikasjonFestenummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
-            titleResourceKey: "col-6",
             dataKey: "bolignummer",
             tagName: "custom-field-data",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.bolignummer.title",
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.bolignummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
-            titleResourceKey: "col-7",
             dataKey: "bygningsnummer",
             tagName: "custom-field-data",
             resourceBindings: {
-                title: "resource.eiendomByggested.eiendom.bygningsnummer.title",
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.bygningsnummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         }
     ];
@@ -83,6 +85,9 @@ export function renderEiendomTable(component) {
         hideIfEmpty: true,
         isChildComponent: true,
         resourceValues: component?.resourceValues,
+        resourceBindings: {
+            title: component?.resourceBindings?.eiendomByggested?.title
+        },
         tableColumns
     });
     const tableElement = createCustomElement("custom-table-data", htmlAttributes);

--- a/src/components/data-components/custom-table-part/renderers.js
+++ b/src/components/data-components/custom-table-part/renderers.js
@@ -5,12 +5,20 @@ import CustomElementHtmlAttributes from "../../../classes/system-classes/CustomE
 import { createCustomElement } from "../../../functions/helpers.js";
 
 /**
- * Renders a custom table part component with predefined columns for part name, phone number, and email.
+ * Renders a custom table part component with specified columns and attributes.
  *
  * @param {Object} component - The component configuration object.
- * @param {string} [component.partType] - The type of part, used for resource key generation.
- * @param {Object} [component.formData] - The form data to be passed to the table.
- * @param {Object} [component.texts] - The text resources to be used for column titles and empty field text.
+ * @param {Object} [component.resourceBindings] - Resource bindings for column titles and empty field text.
+ * @param {Object} [component.resourceBindings.navn] - Resource binding for the "navn" column.
+ * @param {string} [component.resourceBindings.navn.title] - Title for the "navn" column.
+ * @param {Object} [component.resourceBindings.telefonnummer] - Resource binding for the "telefonnummer" column.
+ * @param {string} [component.resourceBindings.telefonnummer.title] - Title for the "telefonnummer" column.
+ * @param {Object} [component.resourceBindings.epost] - Resource binding for the "epost" column.
+ * @param {string} [component.resourceBindings.epost.title] - Title for the "epost" column.
+ * @param {string} [component.resourceBindings.emptyFieldText] - Text to display for empty fields.
+ * @param {Object} [component.resourceBindings.part] - Resource binding for the table part title.
+ * @param {string} [component.resourceBindings.part.title] - Title for the table part.
+ * @param {Object} [component.resourceValues] - Resource values for the table.
  * @returns {HTMLElement} The rendered custom table element.
  */
 export function renderPartTable(component) {
@@ -18,23 +26,23 @@ export function renderPartTable(component) {
         {
             tagName: "custom-field-part-navn",
             resourceBindings: {
-                title: `resource.${component?.partType}.navn.title`,
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.navn?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
             tagName: "custom-field-telefonnummer",
             resourceBindings: {
-                title: `resource.${component?.partType}.telefonnummer.title`,
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.telefonnummer?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         },
         {
             tagName: "custom-field-data",
             dataKey: "epost",
             resourceBindings: {
-                title: `resource.${component?.partType}.epost.title`,
-                emptyFieldText: "resource.emptyFieldText.default"
+                title: component?.resourceBindings?.epost?.title,
+                emptyFieldText: component?.resourceBindings?.emptyFieldText
             }
         }
     ];
@@ -43,6 +51,9 @@ export function renderPartTable(component) {
         hideIfEmpty: true,
         isChildComponent: true,
         resourceValues: component?.resourceValues,
+        resourceBindings: {
+            title: component?.resourceBindings?.part?.title
+        },
         tableColumns
     });
     const tableElement = createCustomElement("custom-table-data", htmlAttributes);


### PR DESCRIPTION
Improves the flexibility of custom table components by introducing custom resource bindings for titles and empty field texts.

This change allows developers to override default resource keys, providing more control over text customization in `CustomTableEiendom` and `CustomTablePart`. It also adds optional title and empty field text hiding.