### PR TITLE
Adds format prop to componentProps

### DIFF
--- a/src/functions/tableHelpers.js
+++ b/src/functions/tableHelpers.js
@@ -39,6 +39,7 @@ export function getTableRows(tableColumns, data) {
             const componentProps = {
                 resourceBindings: column.resourceBindings,
                 resourceValues: { data: cellData },
+                format: column.format,
                 hideTitle: true,
                 tagName: column.tagName,
                 isChildComponent: true


### PR DESCRIPTION
### Adds format prop to componentProps

Ensures the format property from the column definition is passed to the child component.

This allows child components to properly format the data they are displaying.