### PR TITLE
Feature/link support for custom field

### DIFF
--- a/src/classes/system-classes/CustomElementHtmlAttributes.js
+++ b/src/classes/system-classes/CustomElementHtmlAttributes.js
@@ -45,6 +45,8 @@ export default class CustomElementHtmlAttributes {
         const grid = this.getGridAttributeFromProps(props);
         const tableColumns = this.getTableColumnsAttributeFromProps(props);
         const itemKey = this.getItemKeyAttributeFromProps(props);
+        const dataItemKey = this.getDataItemKeyAttributeFromProps(props);
+        const dataTitleItemKey = this.getDataTitleItemKeyAttributeFromProps(props);
         const id = this.getIdAttributeFromProps(props);
         const feedbackType = this.getFeedbackTypeAttributeFromProps(props);
         const hideOrgNr = this.getHideOrgNr(props);
@@ -88,6 +90,12 @@ export default class CustomElementHtmlAttributes {
         }
         if (itemKey) {
             this.itemKey = itemKey;
+        }
+        if (dataItemKey) {
+            this.dataItemKey = dataItemKey;
+        }
+        if (dataTitleItemKey) {
+            this.dataTitleItemKey = dataTitleItemKey;
         }
         if (id) {
             this.id = id;
@@ -264,6 +272,27 @@ export default class CustomElementHtmlAttributes {
      */
     getItemKeyAttributeFromProps(props) {
         return hasValue(props?.itemKey) && props?.itemKey;
+    }
+
+    /**
+     * Retrieves the `dataItemKey` attribute from the given props object if it has a value.
+     *
+     * @param {Object} props - The props object containing potential attributes.
+     * @param {*} props.dataItemKey - The key to be retrieved if it has a value.
+     * @returns {*} The value of `dataItemKey` if it exists and is valid; otherwise, returns undefined or false.
+     */
+    getDataItemKeyAttributeFromProps(props) {
+        return hasValue(props?.dataItemKey) && props?.dataItemKey;
+    }
+
+    /**
+     * Retrieves the 'dataTitleItemKey' attribute from the given props if it has a value.
+     *
+     * @param {Object} props - The properties object to extract the attribute from.
+     * @returns {*} The value of 'dataTitleItemKey' if it exists and is valid; otherwise, returns undefined or a falsy value.
+     */
+    getDataTitleItemKeyAttributeFromProps(props) {
+        return hasValue(props?.dataTitleItemKey) && props?.dataTitleItemKey;
     }
 
     /**

--- a/src/classes/system-classes/component-classes/CustomFieldData.js
+++ b/src/classes/system-classes/component-classes/CustomFieldData.js
@@ -2,7 +2,7 @@
 import CustomComponent from "../CustomComponent.js";
 
 // Global functions
-import { getComponentDataValue, getComponentResourceValue, hasValue } from "../../../functions/helpers.js";
+import { getComponentDataTitle, getComponentDataValue, getComponentResourceValue, hasValue } from "../../../functions/helpers.js";
 import { formatString } from "../../../functions/dataFormatHelpers.js";
 
 /**
@@ -26,12 +26,18 @@ import { formatString } from "../../../functions/dataFormatHelpers.js";
 export default class CustomFieldData extends CustomComponent {
     constructor(props) {
         super(props);
+        console.log(props);
         const data = this.getValueFromFormData(props);
+        const dataTitle = getComponentDataTitle(props);
         const isEmpty = !this.hasContent(data);
+        const isDataTitleEmpty = !this.hasContent(dataTitle);
+        const dataItemKey = this.hasContent(props?.dataItemKey);
+        const dataTitleItemKey = this.hasContent(props?.dataTitleItemKey);
+        console.log(dataItemKey, dataTitleItemKey);
 
         this.isEmpty = isEmpty;
         this.resourceValues = {
-            title: !props?.hideTitle && getComponentResourceValue(props, "title"),
+            title: !props?.hideTitle && ((!isDataTitleEmpty && dataTitle) || getComponentResourceValue(props, "title")),
             data: isEmpty ? getComponentResourceValue(props, "emptyFieldText") : data
         };
     }

--- a/src/classes/system-classes/component-classes/CustomFieldData.js
+++ b/src/classes/system-classes/component-classes/CustomFieldData.js
@@ -26,14 +26,10 @@ import { formatString } from "../../../functions/dataFormatHelpers.js";
 export default class CustomFieldData extends CustomComponent {
     constructor(props) {
         super(props);
-        console.log(props);
         const data = this.getValueFromFormData(props);
         const dataTitle = getComponentDataTitle(props);
         const isEmpty = !this.hasContent(data);
         const isDataTitleEmpty = !this.hasContent(dataTitle);
-        const dataItemKey = this.hasContent(props?.dataItemKey);
-        const dataTitleItemKey = this.hasContent(props?.dataTitleItemKey);
-        console.log(dataItemKey, dataTitleItemKey);
 
         this.isEmpty = isEmpty;
         this.resourceValues = {

--- a/src/classes/system-classes/component-classes/CustomFieldListData.js
+++ b/src/classes/system-classes/component-classes/CustomFieldListData.js
@@ -40,12 +40,7 @@ export default class CustomFieldListData extends CustomComponent {
 
         if (Array.isArray(data) && data.length) {
             this.resourceValues = {
-                data: data.map((titleDataPair) => {
-                    return {
-                        title: titleDataPair.title,
-                        data: titleDataPair.item
-                    };
-                })
+                data
             };
         }
     }
@@ -96,7 +91,7 @@ export default class CustomFieldListData extends CustomComponent {
 
             return Array.from({ length: len }, (_, i) => ({
                 title: dataTitles[i],
-                item: dataItems[i]
+                data: dataItems[i]
             }));
         }
     }

--- a/src/classes/system-classes/component-classes/CustomFieldListData.js
+++ b/src/classes/system-classes/component-classes/CustomFieldListData.js
@@ -1,0 +1,103 @@
+// Classes
+import CustomComponent from "../CustomComponent.js";
+
+// Global functions
+import { getComponentDataValue, hasValue } from "../../../functions/helpers.js";
+
+/**
+ * CustomFieldListData is a custom component class for handling and transforming
+ * list data structures, typically used in form data scenarios.
+ *
+ * @extends CustomComponent
+ *
+ * @param {object} props - The properties passed to the component.
+ * @param {Array|object} props.data - The data to be processed by the component.
+ * @param {string} [props.dataItemKey] - Dot-separated key path to extract item values from data.
+ * @param {string} [props.dataTitleItemKey] - Dot-separated key path to extract title values from data.
+ *
+ * @property {boolean} isEmpty - Indicates if the data is empty.
+ * @property {object} resourceValues - Contains the processed list data with titles and items.
+ *
+ * @method hasContent Checks if the provided form data value is not empty.
+ * @param {*} formDataValue - The value to check for content.
+ * @returns {boolean} True if the value has content, false otherwise.
+ *
+ * @method getListItemsFromKey Extracts a list of values from an array of items using a dot-separated key path.
+ * @param {Array} items - The array of items to extract values from.
+ * @param {string} itemKey - Dot-separated key path to extract the value.
+ * @returns {Array} Array of extracted values.
+ *
+ * @method getValueFromFormData Processes the props to extract and pair titles and items from the data.
+ * @param {object} props - The properties containing data and key paths.
+ * @returns {Array|undefined} Array of objects with title and item properties, or undefined if keys are missing.
+ */
+export default class CustomFieldListData extends CustomComponent {
+    constructor(props) {
+        super(props);
+        const data = this.getValueFromFormData(props);
+        const isEmpty = !this.hasContent(data);
+        this.isEmpty = isEmpty;
+
+        if (Array.isArray(data) && data.length) {
+            this.resourceValues = {
+                data: data.map((titleDataPair) => {
+                    return {
+                        title: titleDataPair.title,
+                        data: titleDataPair.item
+                    };
+                })
+            };
+        }
+    }
+
+    /**
+     * Determines if the provided form data value contains content.
+     *
+     * @param {*} formDataValue - The value from the form data to check.
+     * @returns {boolean} True if the form data value has content; otherwise, false.
+     */
+    hasContent(formDataValue) {
+        return hasValue(formDataValue);
+    }
+
+    /**
+     * Retrieves a list of values from an array of objects based on a dot-separated key path.
+     *
+     * @param {Array<Object>} items - The array of objects to extract values from.
+     * @param {string} itemKey - The dot-separated key path (e.g., "user.name") to retrieve the value from each object.
+     * @returns {Array<*>} An array of values corresponding to the specified key path in each object. Returns an empty array if items is not a valid array or is empty.
+     */
+    getListItemsFromKey(items, itemKey) {
+        if (!Array.isArray(items) || !items.length) return [];
+        const keys = itemKey.split(".");
+        return items.map((item) => {
+            return keys.reduce((obj, key) => obj?.[key], item);
+        });
+    }
+
+    /**
+     * Extracts and pairs title and item values from form data based on provided keys in props.
+     *
+     * @param {Object} props - The properties object containing data and keys.
+     * @param {string} [props.dataItemKey] - The key used to extract item values from the data.
+     * @param {string} [props.dataTitleItemKey] - The key used to extract title values from the data.
+     * @returns {Array<{title: any, item: any}>|undefined} An array of objects each containing a title and item,
+     *   or undefined if required keys are not present.
+     */
+    getValueFromFormData(props) {
+        const dataItemKey = this.hasContent(props?.dataItemKey);
+        const dataTitleItemKey = this.hasContent(props?.dataTitleItemKey);
+        const data = getComponentDataValue(props);
+
+        if (dataItemKey && dataTitleItemKey) {
+            const dataTitles = hasValue(props?.dataTitleItemKey) ? this.getListItemsFromKey(data, props?.dataTitleItemKey) : data;
+            const dataItems = hasValue(props?.dataItemKey) ? this.getListItemsFromKey(data, props?.dataItemKey) : data;
+            const len = Math.min(dataTitles.length, dataItems.length);
+
+            return Array.from({ length: len }, (_, i) => ({
+                title: dataTitles[i],
+                item: dataItems[i]
+            }));
+        }
+    }
+}

--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -1,4 +1,5 @@
 // Global functions
+import { injectAnchorElements } from "../../../functions/dataFormatHelpers.js";
 import { addStyle, hasValue } from "../../../functions/helpers.js";
 
 /**
@@ -35,48 +36,6 @@ function renderFieldValueElement(fieldValue) {
     const htmlContent = hasValue(fieldValue) ? injectAnchorElements(fieldValue) : "";
     fieldValueElement.innerHTML = htmlContent;
     return fieldValueElement;
-}
-
-/**
- * Converts URLs in a given text string into HTML anchor elements.
- *
- * - Detects URLs starting with http(s):// or www.
- * - Splits the text to preserve URLs and non-URL parts.
- * - Escapes HTML in non-link text.
- * - Trims common trailing punctuation from URLs and reattaches it after the anchor.
- * - Ensures links open in a new tab with security attributes.
- *
- * @param {string} text - The input text potentially containing URLs.
- * @returns {string} The HTML string with URLs converted to anchor tags.
- */
-function injectAnchorElements(text) {
-    // One canonical URL pattern
-    const urlPattern = "(?:https?:\\/\\/(?:www\\.)?[a-zA-Z0-9][a-zA-Z0-9-]*\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]*\\.[^\\s]{2,})";
-
-    // 1) Capturing group so split keeps the URL tokens
-    const splitRegex = new RegExp(`(${urlPattern})`, "g");
-
-    // 2) Non-global tester to avoid lastIndex issues
-    const isUrl = new RegExp(`^${urlPattern}$`);
-
-    // Optional: basic HTML escape for non-link parts
-    const escapeHtml = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
-    return text
-        .split(splitRegex)
-        .map((part) => {
-            if (!part) return "";
-            if (isUrl.test(part)) {
-                // Trim common trailing punctuation off the link and re-attach after the anchor
-                const m = part.match(/^(.*?)([).,!?:;]+)?$/);
-                const raw = m[1];
-                const trail = m[2] ?? "";
-                const href = raw.startsWith("http") ? raw : `https://${raw}`;
-                return `<a href="${href}" target="_blank" rel="noopener noreferrer">${raw}</a>${escapeHtml(trail)}`;
-            }
-            return escapeHtml(part);
-        })
-        .join("");
 }
 
 /**

--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -33,7 +33,6 @@ function renderFieldValueElement(fieldValue) {
         fieldValue = JSON.stringify(fieldValue, null, 2);
     }
     const htmlContent = hasValue(fieldValue) ? injectAnchorElements(fieldValue) : "";
-    console.log({ fieldValue, htmlContent });
     fieldValueElement.innerHTML = htmlContent;
     return fieldValueElement;
 }

--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -32,8 +32,52 @@ function renderFieldValueElement(fieldValue) {
     if (typeof fieldValue === "object") {
         fieldValue = JSON.stringify(fieldValue, null, 2);
     }
-    fieldValueElement.innerHTML = hasValue(fieldValue) ? fieldValue : "";
+    const htmlContent = hasValue(fieldValue) ? injectAnchorElements(fieldValue) : "";
+    console.log({ fieldValue, htmlContent });
+    fieldValueElement.innerHTML = htmlContent;
     return fieldValueElement;
+}
+
+/**
+ * Converts URLs in a given text string into HTML anchor elements.
+ *
+ * - Detects URLs starting with http(s):// or www.
+ * - Splits the text to preserve URLs and non-URL parts.
+ * - Escapes HTML in non-link text.
+ * - Trims common trailing punctuation from URLs and reattaches it after the anchor.
+ * - Ensures links open in a new tab with security attributes.
+ *
+ * @param {string} text - The input text potentially containing URLs.
+ * @returns {string} The HTML string with URLs converted to anchor tags.
+ */
+function injectAnchorElements(text) {
+    // One canonical URL pattern
+    const urlPattern = "(?:https?:\\/\\/(?:www\\.)?[a-zA-Z0-9][a-zA-Z0-9-]*\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]*\\.[^\\s]{2,})";
+
+    // 1) Capturing group so split keeps the URL tokens
+    const splitRegex = new RegExp(`(${urlPattern})`, "g");
+
+    // 2) Non-global tester to avoid lastIndex issues
+    const isUrl = new RegExp(`^${urlPattern}$`);
+
+    // Optional: basic HTML escape for non-link parts
+    const escapeHtml = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+    return text
+        .split(splitRegex)
+        .map((part) => {
+            if (!part) return "";
+            if (isUrl.test(part)) {
+                // Trim common trailing punctuation off the link and re-attach after the anchor
+                const m = part.match(/^(.*?)([).,!?:;]+)?$/);
+                const raw = m[1];
+                const trail = m[2] ?? "";
+                const href = raw.startsWith("http") ? raw : `https://${raw}`;
+                return `<a href="${href}" target="_blank" rel="noopener noreferrer">${raw}</a>${escapeHtml(trail)}`;
+            }
+            return escapeHtml(part);
+        })
+        .join("");
 }
 
 /**

--- a/src/components/data-components/custom-field-list-data/README.md
+++ b/src/components/data-components/custom-field-list-data/README.md
@@ -1,0 +1,31 @@
+# Data (field)
+
+| Property                    | Type              | Description                                                                            | Default value |
+| :-------------------------- | :---------------- | :------------------------------------------------------------------------------------- | :------------ |
+| id                          | string            | The unique identifier for the custom field.                                            |               |
+| type                        | string            | The type of the custom field, which is "Custom".                                       |               |
+| tagName                     | string            | The tag name for the custom field, which is "custom-field-data".                       |               |
+| hideIfEmpty                 | boolean           | Determines whether the element should be hidden when it contains no content.           | false         |
+| dataTitleItemKey            | string            | Key for label that will be searched for in the chosen array.                           |               |
+| dataTitleItemKey            | string            | Key for datathat will be searched for in the chosen array.                             |               |
+| inline                      | boolean           | A flag indicating whether the title and value should be displayed on the same line.    | false         |
+| dataModelBindings.dataTitle | string            | Reference to a list in the data model that will be used to display label for the data. |               |
+| dataModelBindings.data      | string            | Reference to a list in the data model that will be used to display data.               |               |
+| styleOverride               | HTMLElement.style | The style override for the custom field.                                               |               |
+
+## Example
+
+```json
+{
+    "id": "gjeldendePlan-andrePlaner",
+    "type": "Custom",
+    "tagName": "custom-field-list-data",
+    "hideIfEmpty": true,
+    "dataTitleItemKey": "plantype.kodebeskrivelse",
+    "dataItemKey": "navn",
+    "dataModelBindings": {
+        "dataTitle": "planer.andrePlaner.plan",
+        "data": "planer.andrePlaner.plan"
+    }
+}
+```

--- a/src/components/data-components/custom-field-list-data/index.js
+++ b/src/components/data-components/custom-field-list-data/index.js
@@ -1,9 +1,7 @@
-// Classes
-import CustomElementHtmlAttributes from "../../../classes/system-classes/CustomElementHtmlAttributes.js";
-
 // Global functions
-import { createCustomElement, getComponentContainerElement } from "../../../functions/helpers.js";
+import { getComponentContainerElement } from "../../../functions/helpers.js";
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderListFieldElement } from "./renderers.js";
 
 export default customElements.define(
     "custom-field-list-data",
@@ -14,17 +12,8 @@ export default customElements.define(
             if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
                 componentContainerElement.style.display = "none";
             } else {
-                component.resourceValues?.data?.forEach((fieldItem) => {
-                    const htmlAttributes = new CustomElementHtmlAttributes({
-                        ...fieldItem,
-                        resourceValues: {
-                            data: fieldItem.data,
-                            title: fieldItem.title
-                        }
-                    });
-                    const fieldItemElement = createCustomElement("custom-field", htmlAttributes).outerHTML;
-                    this.innerHTML += fieldItemElement;
-                });
+                const fieldListDataElement = renderListFieldElement(component);
+                this.innerHTML = fieldListDataElement.outerHTML;
             }
         }
     }

--- a/src/components/data-components/custom-field-list-data/index.js
+++ b/src/components/data-components/custom-field-list-data/index.js
@@ -1,0 +1,31 @@
+// Classes
+import CustomElementHtmlAttributes from "../../../classes/system-classes/CustomElementHtmlAttributes.js";
+
+// Global functions
+import { createCustomElement, getComponentContainerElement } from "../../../functions/helpers.js";
+import { instantiateComponent } from "../../../functions/componentHelpers.js";
+
+export default customElements.define(
+    "custom-field-list-data",
+    class extends HTMLElement {
+        connectedCallback() {
+            const component = instantiateComponent(this);
+            const componentContainerElement = getComponentContainerElement(this);
+            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
+                componentContainerElement.style.display = "none";
+            } else {
+                component.resourceValues?.data?.forEach((fieldItem) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes({
+                        ...fieldItem,
+                        resourceValues: {
+                            data: fieldItem.data,
+                            title: fieldItem.title
+                        }
+                    });
+                    const fieldItemElement = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                    this.innerHTML += fieldItemElement;
+                });
+            }
+        }
+    }
+);

--- a/src/components/data-components/custom-field-list-data/renderers.js
+++ b/src/components/data-components/custom-field-list-data/renderers.js
@@ -1,0 +1,36 @@
+// Classes
+import CustomElementHtmlAttributes from "../../../classes/system-classes/CustomElementHtmlAttributes.js";
+
+// Global functions
+import { addContainerElement, createCustomElement } from "../../../functions/helpers.js";
+
+/**
+ * Renders a custom field data element by creating a custom HTML element
+ * with the provided resource values and wrapping it in a container element.
+ *
+ * @param {Object} resourceValues - The resource values to be passed to the custom element.
+ * @returns {HTMLElement} The container element containing the custom field data element.
+ */
+function renderCustomFieldDataElement(resourceValues) {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        resourceValues
+    });
+    return addContainerElement(createCustomElement("custom-field-data", htmlAttributes));
+}
+
+/**
+ * Renders a list of custom field data elements into a container div.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {Object} [component.resourceValues] - The resource values object.
+ * @param {Array} [component.resourceValues.data] - The array of data items to render.
+ * @returns {HTMLDivElement} A div element containing the rendered custom field data elements.
+ */
+export function renderListFieldElement(component) {
+    const fieldListDataElement = document.createElement("div");
+    component?.resourceValues?.data?.forEach((item) => {
+        fieldListDataElement.appendChild(renderCustomFieldDataElement(item));
+    });
+    return fieldListDataElement;
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -17,6 +17,7 @@ import customFieldBooleanData from "./data-components/custom-field-boolean-data/
 import customFieldBooleanText from "./data-components/custom-field-boolean-text/index.js";
 import customFieldCountData from "./data-components/custom-field-count-data/index.js";
 import customFieldData from "./data-components/custom-field-data/index.js";
+import customFieldListData from "./data-components/custom-field-list-data/index.js";
 import customFieldKommunensSaksnummer from "./data-components/custom-field-kommunens-saksnummer/index.js";
 import customFieldProsjekt from "./data-components/custom-field-prosjekt/index.js";
 import customFieldTelefonnummer from "./data-components/custom-field-telefonnummer/index.js";
@@ -64,6 +65,7 @@ export {
     customFieldBooleanText,
     customFieldCountData,
     customFieldData,
+    customFieldListData,
     customFieldKommunensSaksnummer,
     customFieldProsjekt,
     customFieldTelefonnummer,

--- a/src/constants/customElementTagNames.js
+++ b/src/constants/customElementTagNames.js
@@ -14,6 +14,7 @@ export default [
     "custom-field-boolean-text",
     "custom-field-count-data",
     "custom-field-data",
+    "custom-field-list-data",
     "custom-field-kommunens-saksnummer",
     "custom-field-part-navn",
     "custom-field-prosjekt",

--- a/src/functions/componentHelpers.js
+++ b/src/functions/componentHelpers.js
@@ -11,6 +11,7 @@ import CustomFieldBooleanText from "../classes/system-classes/component-classes/
 import CustomFieldCountData from "../classes/system-classes/component-classes/CustomFieldCountData.js";
 import CustomFieldData from "../classes/system-classes/component-classes/CustomFieldData.js";
 import CustomFieldKommunensSaksnummer from "../classes/system-classes/component-classes/CustomFieldKommunensSaksnummer.js";
+import CustomFieldListData from "../classes/system-classes/component-classes/CustomFieldListData.js";
 import CustomFieldPartNavn from "../classes/system-classes/component-classes/CustomFieldPartNavn.js";
 import CustomFieldProsjekt from "../classes/system-classes/component-classes/CustomFieldProsjekt.js";
 import CustomFieldTelefonnummer from "../classes/system-classes/component-classes/CustomFieldTelefonnummer.js";
@@ -65,6 +66,8 @@ export function instantiateComponent(element) {
             return new CustomFieldCountData(component);
         case "custom-field-data":
             return new CustomFieldData(component);
+        case "custom-field-list-data":
+            return new CustomFieldListData(component);
         case "custom-field-kommunens-saksnummer":
             return new CustomFieldKommunensSaksnummer(component);
         case "custom-field-part-navn":

--- a/src/functions/dataFormatHelpers.js
+++ b/src/functions/dataFormatHelpers.js
@@ -171,3 +171,45 @@ export function formatString(string, format, language = "default") {
 export function isValidHeaderSize(size) {
     return hasValue(size) && validSizeValues.includes(size.toLowerCase());
 }
+
+/**
+ * Converts URLs in a given text string into HTML anchor elements.
+ *
+ * - Detects URLs starting with http(s):// or www.
+ * - Splits the text to preserve URLs and non-URL parts.
+ * - Escapes HTML in non-link text.
+ * - Trims common trailing punctuation from URLs and reattaches it after the anchor.
+ * - Ensures links open in a new tab with security attributes.
+ *
+ * @param {string} text - The input text potentially containing URLs.
+ * @returns {string} The HTML string with URLs converted to anchor tags.
+ */
+export function injectAnchorElements(text) {
+    // One canonical URL pattern
+    const urlPattern = "(?:https?:\\/\\/(?:www\\.)?[a-zA-Z0-9][a-zA-Z0-9-]*\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]*\\.[^\\s]{2,})";
+
+    // 1) Capturing group so split keeps the URL tokens
+    const splitRegex = new RegExp(`(${urlPattern})`, "g");
+
+    // 2) Non-global tester to avoid lastIndex issues
+    const isUrl = new RegExp(`^${urlPattern}$`);
+
+    // Optional: basic HTML escape for non-link parts
+    const escapeHtml = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+    return text
+        .split(splitRegex)
+        .map((part) => {
+            if (!part) return "";
+            if (isUrl.test(part)) {
+                // Trim common trailing punctuation off the link and re-attach after the anchor
+                const m = part.match(/^(.*?)([).,!?:;]+)?$/);
+                const raw = m[1];
+                const trail = m[2] ?? "";
+                const href = raw.startsWith("http") ? raw : `https://${raw}`;
+                return `<a href="${href}" target="_blank" rel="noopener noreferrer">${raw}</a>${escapeHtml(trail)}`;
+            }
+            return escapeHtml(part);
+        })
+        .join("");
+}

--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -324,6 +324,19 @@ export function getComponentDataValue(component) {
         return component.formData?.simpleBinding || component.formData?.data;
     }
 }
+/**
+ * Retrieves the data title from a component's formData if it exists.
+ *
+ * @param {Object} component - The component object containing formData.
+ * @param {Object} [component.formData] - The formData object of the component.
+ * @param {string} [component.formData.dataTitle] - The data title to retrieve.
+ * @returns {string|undefined} The data title if present, otherwise undefined.
+ */
+export function getComponentDataTitle(component) {
+    if (component.formData?.dataTitle != null) {
+        return component.formData?.dataTitle;
+    }
+}
 
 /**
  * Retrieves boolean data values (trueData, falseData, defaultData) from a component object.

--- a/src/functions/htmlElementHelpers.js
+++ b/src/functions/htmlElementHelpers.js
@@ -41,6 +41,8 @@ export function getPropsFromElementAttributes(element) {
         isChildComponent: getIsChildComponent(element),
         feedbackType: getFeedbackType(element),
         itemKey: getItemKey(element),
+        dataItemKey: getDataItemKey(element),
+        dataTitleItemKey: getDataTitleItemKey(element),
         hideOrgNr: getHideOrgNr(element),
         format: getFormat(element),
         tableColumns: getTableColumns(element),
@@ -177,6 +179,30 @@ function getFeedbackType(element) {
 function getItemKey(element) {
     const itemKey = element?.getAttribute("itemKey");
     return hasValue(itemKey) && itemKey;
+}
+
+/**
+ * Retrieves the value of the "dataItemKey" attribute from the given HTML element.
+ * Returns the value only if it is defined and not empty, otherwise returns false.
+ *
+ * @param {HTMLElement} element - The HTML element to extract the dataItemKey from.
+ * @returns {(string|false)} The value of the dataItemKey attribute if present and valid, otherwise false.
+ */
+function getDataItemKey(element) {
+    const dataItemKey = element?.getAttribute("dataItemKey");
+    return hasValue(dataItemKey) && dataItemKey;
+}
+
+/**
+ * Retrieves the value of the "dataTitleItemKey" attribute from the given HTML element,
+ * if it exists and is considered valid by the `hasValue` function.
+ *
+ * @param {HTMLElement} element - The HTML element from which to retrieve the attribute.
+ * @returns {string|false} The value of the "dataTitleItemKey" attribute if valid, otherwise false.
+ */
+function getDataTitleItemKey(element) {
+    const dataTitleItemKey = element?.getAttribute("dataTitleItemKey");
+    return hasValue(dataTitleItemKey) && dataTitleItemKey;
 }
 
 /**


### PR DESCRIPTION
# Implements custom field list component and enhances custom field data

This diff introduces a new `custom-field-list-data` component for rendering lists of custom fields. It also adds support for specifying data item and title keys within custom field data, enabling extraction of specific values from complex data structures. URLs in custom fields are now automatically converted to links.

## Changes
- **Added** `CustomFieldListData.js` and associated files for rendering lists of custom fields based on data and title keys.  
- **Introduced** `dataItemKey` and `dataTitleItemKey` attributes to `CustomElementHtmlAttributes.js` to support extracting specific data points from nested data structures for both the new list component and existing `CustomFieldData`.  
- **Modified** `CustomFieldData.js` to utilize `getComponentDataTitle` for retrieving data titles, and handle the case where a `dataTitle` is provided in the props.  
- **Implemented** `injectAnchorElements` in `dataFormatHelpers.js` to convert URLs to clickable links in custom field values. This function escapes HTML in non-link parts of the text.  
- **Updated** `renderFieldValueElement` in `renderers.js` to use `injectAnchorElements` for URL conversion.  

## Impact
- Introduces a new component, `custom-field-list-data`, allowing for flexible rendering of list-based data.  
- Enhances the `custom-field-data` component to support more complex data structures through the introduction of `dataItemKey` and `dataTitleItemKey`.  
- Improves user experience by automatically converting URLs in custom fields to clickable links.  
- The addition of `injectAnchorElements` may have a slight performance impact due to the added processing, but this is likely negligible in most cases.  
