### PR TITLE
Feature/bugfix data tables

### DIFF
--- a/src/classes/system-classes/component-classes/CustomTableEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomTableEiendom.js
@@ -172,31 +172,15 @@ export default class CustomTableEiendom extends CustomComponent {
 
     /**
      * Generates an object containing text resource bindings for various property fields.
-     * The bindings are determined by the provided `props` object, falling back to default resource keys if not specified.
+     * Each field includes a `title` and `emptyFieldText`, which can be overridden by values in `props.resourceBindings`.
+     * Default resource keys are used if overrides are not provided.
+     * Optionally adds `eiendomByggested` resource bindings based on `hideTitle` and `hideIfEmpty` props.
      *
-     * @param {Object} props - The properties object containing resource bindings and configuration flags.
-     * @param {Object} [props.resourceBindings] - Custom resource bindings for each field.
-     * @param {Object} [props.resourceBindings.adresse] - Resource bindings for the address field.
-     * @param {string} [props.resourceBindings.adresse.title] - Custom title for the address field.
-     * @param {string} [props.resourceBindings.adresse.emptyFieldText] - Custom empty field text for the address field.
-     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon] - Resource bindings for property identification fields.
-     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.gaardsnummer] - Resource bindings for gaardsnummer.
-     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.gaardsnummer.title] - Custom title for gaardsnummer.
-     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.bruksnummer] - Resource bindings for bruksnummer.
-     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.bruksnummer.title] - Custom title for bruksnummer.
-     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.seksjonsnummer] - Resource bindings for seksjonsnummer.
-     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.seksjonsnummer.title] - Custom title for seksjonsnummer.
-     * @param {Object} [props.resourceBindings.eiendomsidentifikasjon.festenummer] - Resource bindings for festenummer.
-     * @param {string} [props.resourceBindings.eiendomsidentifikasjon.festenummer.title] - Custom title for festenummer.
-     * @param {Object} [props.resourceBindings.bolignummer] - Resource bindings for bolignummer.
-     * @param {string} [props.resourceBindings.bolignummer.title] - Custom title for bolignummer.
-     * @param {Object} [props.resourceBindings.bygningsnummer] - Resource bindings for bygningsnummer.
-     * @param {string} [props.resourceBindings.bygningsnummer.title] - Custom title for bygningsnummer.
-     * @param {string} [props.resourceBindings.title] - Custom title for eiendomByggested.
-     * @param {string} [props.resourceBindings.emptyFieldText] - Custom empty field text for eiendomByggested.
-     * @param {boolean|string} [props.hideTitle] - If true or "true", omits the eiendomByggested title binding.
-     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", omits the eiendomByggested empty field text binding.
-     * @returns {Object} An object containing the resolved text resource bindings for each field.
+     * @param {Object} props - The properties object.
+     * @param {Object} [props.resourceBindings] - Optional resource bindings to override defaults.
+     * @param {boolean|string} [props.hideTitle] - If true or "true", omits the `eiendomByggested.title` binding.
+     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", omits the `eiendomByggested.emptyFieldText` binding.
+     * @returns {Object} An object containing resource bindings for property fields.
      */
     getTextResourceBindings(props) {
         const resourceBindings = {
@@ -207,28 +191,34 @@ export default class CustomTableEiendom extends CustomComponent {
             eiendomsidentifikasjonGaardsnummer: {
                 title:
                     props?.resourceBindings?.eiendomsidentifikasjon?.gaardsnummer?.title ||
-                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.gaardsnummer.title"
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.gaardsnummer.title",
+                emptyFieldText: props?.resourceBindings?.eiendomsidentifikasjon?.gaardsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             eiendomsidentifikasjonBruksnummer: {
                 title:
                     props?.resourceBindings?.eiendomsidentifikasjon?.bruksnummer?.title ||
-                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.bruksnummer.title"
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.bruksnummer.title",
+                emptyFieldText: props?.resourceBindings?.eiendomsidentifikasjon?.bruksnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             eiendomsidentifikasjonSeksjonsnummer: {
                 title:
                     props?.resourceBindings?.eiendomsidentifikasjon?.seksjonsnummer?.title ||
-                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.seksjonsnummer.title"
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.seksjonsnummer.title",
+                emptyFieldText: props?.resourceBindings?.eiendomsidentifikasjon?.seksjonsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             eiendomsidentifikasjonFestenummer: {
                 title:
                     props?.resourceBindings?.eiendomsidentifikasjon?.festenummer?.title ||
-                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.festenummer.title"
+                    "resource.eiendomByggested.eiendom.eiendomsidentifikasjon.festenummer.title",
+                emptyFieldText: props?.resourceBindings?.eiendomsidentifikasjon?.festenummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             bolignummer: {
-                title: props?.resourceBindings?.bolignummer?.title || "resource.eiendomByggested.eiendom.bolignummer.title"
+                title: props?.resourceBindings?.bolignummer?.title || "resource.eiendomByggested.eiendom.bolignummer.title",
+                emptyFieldText: props?.resourceBindings?.bolignummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             bygningsnummer: {
-                title: props?.resourceBindings?.bygningsnummer?.title || "resource.eiendomByggested.eiendom.bygningsnummer.title"
+                title: props?.resourceBindings?.bygningsnummer?.title || "resource.eiendomByggested.eiendom.bygningsnummer.title",
+                emptyFieldText: props?.resourceBindings?.bygningsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             }
         };
         if (!props?.hideTitle === true || !props?.hideTitle === "true") {

--- a/src/classes/system-classes/component-classes/CustomTableEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomTableEiendom.js
@@ -37,7 +37,7 @@ export default class CustomTableEiendom extends CustomComponent {
         this.hasValidationMessages = hasValidationMessages(validationMessages);
         this.resourceBindings = resourceBindings;
         this.resourceValues = {
-            data: isEmpty ? getTextResourceFromResourceBinding(props?.resourceBindings?.emptyFieldText) : data
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.eiendomByggested?.emptyFieldText) : data
         };
     }
 

--- a/src/classes/system-classes/component-classes/CustomTablePart.js
+++ b/src/classes/system-classes/component-classes/CustomTablePart.js
@@ -155,13 +155,16 @@ export default class CustomTablePart extends CustomComponent {
         const partType = props?.partType || "tiltakshaver";
         const resourceBindings = {
             navn: {
-                title: props?.resourceBindings?.navn?.title || `resource.${partType}.navn.title`
+                title: props?.resourceBindings?.navn?.title || `resource.${partType}.navn.title`,
+                emptyFieldText: props?.resourceBindings?.navn?.emptyFieldText || "resource.emptyFieldText.default"
             },
             telefonnummer: {
-                title: props?.resourceBindings?.telefonnummer?.title || `resource.${partType}.telefonnummer.title`
+                title: props?.resourceBindings?.telefonnummer?.title || `resource.${partType}.telefonnummer.title`,
+                emptyFieldText: props?.resourceBindings?.telefonnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             epost: {
-                title: props?.resourceBindings?.epost?.title || `resource.${partType}.epost.title`
+                title: props?.resourceBindings?.epost?.title || `resource.${partType}.epost.title`,
+                emptyFieldText: props?.resourceBindings?.epost?.emptyFieldText || "resource.emptyFieldText.default"
             }
         };
         if (!props?.hideTitle === true || !props?.hideTitle === "true") {

--- a/src/components/data-components/custom-table-eiendom/renderers.js
+++ b/src/components/data-components/custom-table-eiendom/renderers.js
@@ -36,7 +36,7 @@ export function renderEiendomTable(component) {
             tagName: "custom-field-data",
             resourceBindings: {
                 title: component?.resourceBindings?.eiendomsidentifikasjonGaardsnummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.eiendomsidentifikasjonGaardsnummer?.emptyFieldText
             }
         },
         {
@@ -44,7 +44,7 @@ export function renderEiendomTable(component) {
             tagName: "custom-field-data",
             resourceBindings: {
                 title: component?.resourceBindings?.eiendomsidentifikasjonBruksnummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.eiendomsidentifikasjonBruksnummer?.emptyFieldText
             }
         },
         {
@@ -52,7 +52,7 @@ export function renderEiendomTable(component) {
             tagName: "custom-field-data",
             resourceBindings: {
                 title: component?.resourceBindings?.eiendomsidentifikasjonSeksjonsnummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.eiendomsidentifikasjonSeksjonsnummer?.emptyFieldText
             }
         },
         {
@@ -60,7 +60,7 @@ export function renderEiendomTable(component) {
             tagName: "custom-field-data",
             resourceBindings: {
                 title: component?.resourceBindings?.eiendomsidentifikasjonFestenummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.eiendomsidentifikasjonFestenummer?.emptyFieldText
             }
         },
         {
@@ -68,7 +68,7 @@ export function renderEiendomTable(component) {
             tagName: "custom-field-data",
             resourceBindings: {
                 title: component?.resourceBindings?.bolignummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.bolignummer?.emptyFieldText
             }
         },
         {
@@ -76,7 +76,7 @@ export function renderEiendomTable(component) {
             tagName: "custom-field-data",
             resourceBindings: {
                 title: component?.resourceBindings?.bygningsnummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.bygningsnummer?.emptyFieldText
             }
         }
     ];

--- a/src/components/data-components/custom-table-part/renderers.js
+++ b/src/components/data-components/custom-table-part/renderers.js
@@ -8,15 +8,17 @@ import { createCustomElement } from "../../../functions/helpers.js";
  * Renders a custom table part component with specified columns and attributes.
  *
  * @param {Object} component - The component configuration object.
- * @param {Object} [component.resourceBindings] - Resource bindings for column titles and empty field text.
- * @param {Object} [component.resourceBindings.navn] - Resource binding for the "navn" column.
+ * @param {Object} [component.resourceBindings] - Resource bindings for table columns and title.
+ * @param {Object} [component.resourceBindings.navn] - Resource bindings for the "navn" column.
  * @param {string} [component.resourceBindings.navn.title] - Title for the "navn" column.
- * @param {Object} [component.resourceBindings.telefonnummer] - Resource binding for the "telefonnummer" column.
+ * @param {string} [component.resourceBindings.navn.emptyFieldText] - Text to display when the "navn" field is empty.
+ * @param {Object} [component.resourceBindings.telefonnummer] - Resource bindings for the "telefonnummer" column.
  * @param {string} [component.resourceBindings.telefonnummer.title] - Title for the "telefonnummer" column.
- * @param {Object} [component.resourceBindings.epost] - Resource binding for the "epost" column.
+ * @param {string} [component.resourceBindings.telefonnummer.emptyFieldText] - Text to display when the "telefonnummer" field is empty.
+ * @param {Object} [component.resourceBindings.epost] - Resource bindings for the "epost" column.
  * @param {string} [component.resourceBindings.epost.title] - Title for the "epost" column.
- * @param {string} [component.resourceBindings.emptyFieldText] - Text to display for empty fields.
- * @param {Object} [component.resourceBindings.part] - Resource binding for the table part title.
+ * @param {string} [component.resourceBindings.epost.emptyFieldText] - Text to display when the "epost" field is empty.
+ * @param {Object} [component.resourceBindings.part] - Resource bindings for the table part title.
  * @param {string} [component.resourceBindings.part.title] - Title for the table part.
  * @param {Object} [component.resourceValues] - Resource values for the table.
  * @returns {HTMLElement} The rendered custom table element.
@@ -27,14 +29,14 @@ export function renderPartTable(component) {
             tagName: "custom-field-part-navn",
             resourceBindings: {
                 title: component?.resourceBindings?.navn?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.navn?.emptyFieldText
             }
         },
         {
             tagName: "custom-field-telefonnummer",
             resourceBindings: {
                 title: component?.resourceBindings?.telefonnummer?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.telefonnummer?.emptyFieldText
             }
         },
         {
@@ -42,7 +44,7 @@ export function renderPartTable(component) {
             dataKey: "epost",
             resourceBindings: {
                 title: component?.resourceBindings?.epost?.title,
-                emptyFieldText: component?.resourceBindings?.emptyFieldText
+                emptyFieldText: component?.resourceBindings?.epost?.emptyFieldText
             }
         }
     ];

--- a/src/functions/dataFormatHelpers.js
+++ b/src/functions/dataFormatHelpers.js
@@ -197,7 +197,7 @@ export function injectAnchorElements(text) {
     // Optional: basic HTML escape for non-link parts
     const escapeHtml = (s) => String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
-    return text
+    return text.toString()
         .split(splitRegex)
         .map((part) => {
             if (!part) return "";


### PR DESCRIPTION
Adds empty field text support and improves resource binding.

This pull request adds support for displaying custom text when data fields are empty in custom tables. It enhances resource binding flexibility and updates the empty data text resource binding in `CustomTableEiendom`, `CustomTablePart`, and related renderer components. Also, converts input to String to avoid errors.

### Changes

- Added `emptyFieldText` property to resource bindings in `CustomTableEiendom.js` and `CustomTablePart.js` to allow specifying custom text for empty fields. Default value `resource.emptyFieldText.default` is used when no specific text is provided.
- Modified `getTextResourceBindings` in `CustomTableEiendom.js` to include `emptyFieldText` for each property, using the provided resource bindings or a default value.
- Updated `renderEiendomTable` and `renderPartTable` in `renderers.js` to use the `emptyFieldText` from the resource bindings of each column.
- Modified `injectAnchorElements` in `dataFormatHelpers.js` to convert the input to string to avoid errors.

### Impact

- Allows for more customizable and informative display of empty data fields in custom tables, enhancing the user experience.
- The resource binding changes provide greater control over the text displayed in different scenarios.
- The added emptyFieldText properties in the resource bindings will be used when rendering the custom table.
- Dependencies are not explicitly affected.
