### PR TITLE
Feature/generalize group lists

### DIFF
--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
@@ -73,12 +73,13 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
     }
 
     /**
-     * Generates and returns resource bindings for various UI fields.
+     * Generates resource bindings for the component based on provided props.
      *
-     * The returned object contains resource keys for status, tema, kommentar, and vedleggsliste fields.
-     * Optionally includes an `emptyFieldText` binding if `props.hideIfEmpty` is not set to true or "true".
-     *
-     * @returns {Object} An object with a single property `utfallSvar` containing resource bindings.
+     * @param {Object} props - The properties object.
+     * @param {boolean|string} [props.hideIfEmpty] - Determines if the empty field text should be hidden.
+     * @param {Object} [props.resourceBindings] - Optional custom resource bindings.
+     * @param {string} [props.resourceBindings.emptyFieldText] - Custom text for empty fields.
+     * @returns {Object} An object containing resource bindings for `utfallSvar`.
      */
     getResourceBindings(props) {
         const resourceBindings = {

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
@@ -3,7 +3,7 @@ import CustomComponent from "../CustomComponent.js";
 import UtfallSvar from "../../data-classes/UtfallSvar.js";
 
 // Global functions
-import { getComponentDataValue, getComponentResourceValue, getTextResources, hasValue } from "../../../functions/helpers.js";
+import { getComponentDataValue, getTextResourceFromResourceBinding, getTextResources, hasValue } from "../../../functions/helpers.js";
 import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
 /**
@@ -25,7 +25,7 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
     constructor(props) {
         super(props);
         const data = this.getValueFromFormData(props);
-        const resourceBindings = this.getResourceBindings();
+        const resourceBindings = this.getResourceBindings(props);
 
         const isEmpty = !this.hasContent(data);
         const validationMessages = this.getValidationMessages(resourceBindings);
@@ -35,7 +35,7 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
         this.hasValidationMessages = hasValidationMessages(validationMessages);
         this.resourceBindings = resourceBindings?.utfallSvar || {};
         this.resourceValues = {
-            data: isEmpty ? getComponentResourceValue(props, "emptyFieldText") : data
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.utfallSvar?.emptyFieldText) : data
         };
     }
 
@@ -61,10 +61,10 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
     }
 
     /**
-     * Retrieves the value for this component from the provided form data.
+     * Retrieves the value from form data, constructs an UtfallSvar instance with it, and returns the instance.
      *
-     * @param {Object} props - The properties containing form data and component information.
-     * @returns {*} The value extracted from the form data for this component.
+     * @param {Object} props - The properties containing form data for the component.
+     * @returns {UtfallSvar} An instance of UtfallSvar initialized with the component's data value.
      */
     getValueFromFormData(props) {
         const data = getComponentDataValue(props);
@@ -73,17 +73,23 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
     }
 
     /**
-     * Returns an object containing resource bindings for various fields in the "utfallSvar" group.
+     * Generates and returns resource bindings for various UI fields.
      *
-     * @returns {Object} An object with a single property `utfallSvar`, which maps field keys to their corresponding resource binding strings.
+     * The returned object contains resource keys for status, tema, kommentar, and vedleggsliste fields.
+     * Optionally includes an `emptyFieldText` binding if `props.hideIfEmpty` is not set to true or "true".
+     *
+     * @returns {Object} An object with a single property `utfallSvar` containing resource bindings.
      */
-    getResourceBindings() {
+    getResourceBindings(props) {
         const resourceBindings = {
             "status.title": "resource.utfallBesvarelse.utfallSvar.status.title",
             "tema.kodebeskrivelse.title": "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title",
             "kommentar.title": "resource.utfallBesvarelse.utfallSvar.kommentar.title",
             "vedleggsliste.vedlegg.title": "resource.utfallBesvarelse.utfallSvar.vedleggsliste.vedlegg.title"
         };
+        if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
+            resourceBindings.emptyFieldText = props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default";
+        }
         return {
             utfallSvar: resourceBindings
         };

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
@@ -1,5 +1,6 @@
 // Classes
 import CustomComponent from "../CustomComponent.js";
+import UtfallSvar from "../../data-classes/UtfallSvar.js";
 
 // Global functions
 import { getComponentDataValue, getComponentResourceValue, getTextResources, hasValue } from "../../../functions/helpers.js";
@@ -66,7 +67,9 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
      * @returns {*} The value extracted from the form data for this component.
      */
     getValueFromFormData(props) {
-        return getComponentDataValue(props);
+        const data = getComponentDataValue(props);
+        const utfallSvar = new UtfallSvar(data);
+        return utfallSvar;
     }
 
     /**

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.test.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.test.js
@@ -1,17 +1,13 @@
 import CustomGroupUtfallSvar from "./CustomGroupUtfallSvar";
+import UtfallSvar from "../../data-classes/UtfallSvar";
 import CustomComponent from "../CustomComponent";
-import {
-    getComponentDataValue,
-    getComponentResourceValue,
-    getTextResources,
-    hasValue
-} from "../../../functions/helpers";
+import { getComponentDataValue, getTextResourceFromResourceBinding, getTextResources, hasValue } from "../../../functions/helpers";
 import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations";
 
-// Mock dependencies
+// Mocks for helpers and validations
 jest.mock("../../../functions/helpers", () => ({
     getComponentDataValue: jest.fn(),
-    getComponentResourceValue: jest.fn(),
+    getTextResourceFromResourceBinding: jest.fn(),
     getTextResources: jest.fn(),
     hasValue: jest.fn()
 }));
@@ -21,112 +17,121 @@ jest.mock("../../../functions/validations", () => ({
 }));
 
 describe("CustomGroupUtfallSvar", () => {
-    let props;
-
     beforeEach(() => {
-        props = { some: "prop" };
-        getComponentDataValue.mockClear();
-        getComponentResourceValue.mockClear();
-        getTextResources.mockClear();
-        hasValue.mockClear();
-        hasMissingTextResources.mockClear();
-        hasValidationMessages.mockClear();
+        jest.clearAllMocks();
     });
 
     it("should extend CustomComponent", () => {
-        expect(CustomGroupUtfallSvar.prototype instanceof CustomComponent).toBe(true);
+        const instance = new CustomGroupUtfallSvar({});
+        expect(instance instanceof CustomComponent).toBe(true);
     });
 
     it("should set isEmpty to true if hasContent returns false", () => {
-        getComponentDataValue.mockReturnValue(undefined);
         hasValue.mockReturnValue(false);
-        getComponentResourceValue.mockReturnValue("empty");
+        getComponentDataValue.mockReturnValue("someData");
+        getTextResourceFromResourceBinding.mockReturnValue("emptyText");
         hasMissingTextResources.mockReturnValue(false);
         hasValidationMessages.mockReturnValue(false);
 
+        const props = {};
         const instance = new CustomGroupUtfallSvar(props);
+
         expect(instance.isEmpty).toBe(true);
-        expect(instance.resourceValues.data).toBe("empty");
+        expect(instance.resourceValues.data).toBe("emptyText");
     });
 
     it("should set isEmpty to false if hasContent returns true", () => {
-        getComponentDataValue.mockReturnValue("data");
         hasValue.mockReturnValue(true);
+        getComponentDataValue.mockReturnValue("someData");
         hasMissingTextResources.mockReturnValue(false);
         hasValidationMessages.mockReturnValue(false);
 
+        const props = {};
         const instance = new CustomGroupUtfallSvar(props);
+
         expect(instance.isEmpty).toBe(false);
-        expect(instance.resourceValues.data).toBe("data");
+        expect(instance.resourceValues.data).toBeInstanceOf(UtfallSvar);
     });
 
-    it("should set validationMessages and hasValidationMessages correctly", () => {
-        getComponentDataValue.mockReturnValue("data");
+    it("should set hasValidationMessages based on hasValidationMessages helper", () => {
         hasValue.mockReturnValue(true);
-        hasMissingTextResources.mockReturnValue({ missing: true });
+        getComponentDataValue.mockReturnValue("someData");
+        hasMissingTextResources.mockReturnValue("validationMessages");
         hasValidationMessages.mockReturnValue(true);
 
+        const props = {};
         const instance = new CustomGroupUtfallSvar(props);
-        expect(instance.validationMessages).toEqual({ missing: true });
+
         expect(instance.hasValidationMessages).toBe(true);
+        expect(instance.validationMessages).toBe("validationMessages");
     });
 
-    it("should set resourceBindings to utfallSvar object", () => {
-        getComponentDataValue.mockReturnValue("data");
-        hasValue.mockReturnValue(true);
+    it("should use custom emptyFieldText from props.resourceBindings", () => {
+        hasValue.mockReturnValue(false);
+        getComponentDataValue.mockReturnValue("someData");
+        getTextResourceFromResourceBinding.mockReturnValue("customEmptyText");
         hasMissingTextResources.mockReturnValue(false);
         hasValidationMessages.mockReturnValue(false);
 
+        const props = {
+            resourceBindings: {
+                emptyFieldText: "custom.empty.text"
+            }
+        };
         const instance = new CustomGroupUtfallSvar(props);
-        expect(instance.resourceBindings).toEqual({
-            "status.title": "resource.utfallBesvarelse.utfallSvar.status.title",
-            "tema.kodebeskrivelse.title": "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title",
-            "kommentar.title": "resource.utfallBesvarelse.utfallSvar.kommentar.title",
-            "vedleggsliste.vedlegg.title": "resource.utfallBesvarelse.utfallSvar.vedleggsliste.vedlegg.title"
-        });
+
+        expect(instance.resourceBindings.emptyFieldText).toBe("custom.empty.text");
+        expect(instance.resourceValues.data).toBe("customEmptyText");
     });
 
-    describe("hasContent", () => {
-        it("should call hasValue with data", () => {
-            hasValue.mockReturnValue(true);
-            const instance = new CustomGroupUtfallSvar(props);
-            instance.hasContent("abc");
-            expect(hasValue).toHaveBeenCalledWith("abc");
-        });
+    it("should not set emptyFieldText if hideIfEmpty is true", () => {
+        hasValue.mockReturnValue(true);
+        getComponentDataValue.mockReturnValue("someData");
+        hasMissingTextResources.mockReturnValue(false);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = {
+            hideIfEmpty: true
+        };
+        const instance = new CustomGroupUtfallSvar(props);
+
+        expect(instance.resourceBindings.emptyFieldText).toBeUndefined();
     });
 
-    describe("getValidationMessages", () => {
-        it("should call hasMissingTextResources with textResources and resourceBindings", () => {
-            getTextResources.mockReturnValue({ txt: "res" });
-            hasMissingTextResources.mockReturnValue(false);
-            const instance = new CustomGroupUtfallSvar(props);
-            const bindings = { foo: "bar" };
-            instance.getValidationMessages(bindings);
-            expect(getTextResources).toHaveBeenCalled();
-            expect(hasMissingTextResources).toHaveBeenCalledWith({ txt: "res" }, bindings);
-        });
+    it("getResourceBindings should return default bindings and emptyFieldText if hideIfEmpty is not true", () => {
+        const instance = new CustomGroupUtfallSvar({});
+        const bindings = instance.getResourceBindings({});
+        expect(bindings.utfallSvar["status.title"]).toBeDefined();
+        expect(bindings.utfallSvar.emptyFieldText).toBe("resource.emptyFieldText.default");
     });
 
-    describe("getValueFromFormData", () => {
-        it("should call getComponentDataValue with props", () => {
-            getComponentDataValue.mockReturnValue("value");
-            const instance = new CustomGroupUtfallSvar(props);
-            expect(instance.getValueFromFormData(props)).toBe("value");
-            expect(getComponentDataValue).toHaveBeenCalledWith(props);
-        });
+    it("getResourceBindings should not include emptyFieldText if hideIfEmpty is true", () => {
+        const instance = new CustomGroupUtfallSvar({});
+        const bindings = instance.getResourceBindings({ hideIfEmpty: true });
+        expect(bindings.utfallSvar.emptyFieldText).toBeUndefined();
     });
 
-    describe("getResourceBindings", () => {
-        it("should return correct resourceBindings object", () => {
-            const instance = new CustomGroupUtfallSvar(props);
-            expect(instance.getResourceBindings()).toEqual({
-                utfallSvar: {
-                    "status.title": "resource.utfallBesvarelse.utfallSvar.status.title",
-                    "tema.kodebeskrivelse.title": "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title",
-                    "kommentar.title": "resource.utfallBesvarelse.utfallSvar.kommentar.title",
-                    "vedleggsliste.vedlegg.title": "resource.utfallBesvarelse.utfallSvar.vedleggsliste.vedlegg.title"
-                }
-            });
-        });
+    it("hasContent should delegate to hasValue", () => {
+        hasValue.mockReturnValue(true);
+        const instance = new CustomGroupUtfallSvar({});
+        expect(instance.hasContent("data")).toBe(true);
+        expect(hasValue).toHaveBeenCalledWith("data");
+    });
+
+    it("getValidationMessages should call hasMissingTextResources with textResources and resourceBindings", () => {
+        getTextResources.mockReturnValue("resources");
+        hasMissingTextResources.mockReturnValue("missing");
+        const instance = new CustomGroupUtfallSvar({});
+        const result = instance.getValidationMessages("bindings");
+        expect(getTextResources).toHaveBeenCalled();
+        expect(hasMissingTextResources).toHaveBeenCalledWith("resources", "bindings");
+        expect(result).toBe("missing");
+    });
+
+    it("getValueFromFormData should return UtfallSvar instance", () => {
+        getComponentDataValue.mockReturnValue("data");
+        const instance = new CustomGroupUtfallSvar({});
+        const result = instance.getValueFromFormData({});
+        expect(result).toBeInstanceOf(UtfallSvar);
     });
 });

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.js
@@ -2,13 +2,7 @@
 import CustomComponent from "../CustomComponent.js";
 
 // Global functions
-import {
-    getComponentDataValue,
-    getComponentResourceValue,
-    getTextResourceFromResourceBinding,
-    getTextResources,
-    hasValue
-} from "../../../functions/helpers.js";
+import { getComponentDataValue, getComponentResourceValue, getTextResources, hasValue } from "../../../functions/helpers.js";
 import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
 /**
@@ -38,8 +32,10 @@ export default class CustomGroupUtfallSvarType extends CustomComponent {
         this.isEmpty = isEmpty;
         this.validationMessages = validationMessages;
         this.hasValidationMessages = hasValidationMessages(validationMessages);
+        this.resourceBindings = {
+            title: resourceBindings?.utfallSvarType?.title
+        };
         this.resourceValues = {
-            title: !props?.hideTitle ? getTextResourceFromResourceBinding(resourceBindings?.utfallSvarType?.title) : undefined,
             data: isEmpty ? getComponentResourceValue(props, "emptyFieldText") : data
         };
     }

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.test.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.test.js
@@ -1,18 +1,11 @@
 import CustomGroupUtfallSvarType from "./CustomGroupUtfallSvarType";
-import {
-    getComponentDataValue,
-    getComponentResourceValue,
-    getTextResourceFromResourceBinding,
-    getTextResources,
-    hasValue
-} from "../../../functions/helpers.js";
+import { getComponentDataValue, getComponentResourceValue, getTextResources, hasValue } from "../../../functions/helpers.js";
 import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
 // Mocks for dependencies
 jest.mock("../../../functions/helpers.js", () => ({
     getComponentDataValue: jest.fn(),
     getComponentResourceValue: jest.fn(),
-    getTextResourceFromResourceBinding: jest.fn(),
     getTextResources: jest.fn(),
     hasValue: jest.fn()
 }));
@@ -26,105 +19,95 @@ describe("CustomGroupUtfallSvarType", () => {
         jest.clearAllMocks();
     });
 
-    it("should set isEmpty to true if data is empty", () => {
+    it("should set isEmpty to true if hasContent returns false", () => {
         getComponentDataValue.mockReturnValue(null);
         hasValue.mockReturnValue(false);
         getComponentResourceValue.mockReturnValue("Empty");
-        getTextResourceFromResourceBinding.mockReturnValue("Title");
         hasMissingTextResources.mockReturnValue([]);
         hasValidationMessages.mockReturnValue(false);
 
-        const props = {
-            resourceValues: { utfallType: "YES" }
-        };
+        const props = {};
         const instance = new CustomGroupUtfallSvarType(props);
 
         expect(instance.isEmpty).toBe(true);
         expect(instance.resourceValues.data).toBe("Empty");
     });
 
-    it("should set isEmpty to false if data is present", () => {
+    it("should set isEmpty to false if hasContent returns true", () => {
         getComponentDataValue.mockReturnValue("Some value");
         hasValue.mockReturnValue(true);
-        getTextResourceFromResourceBinding.mockReturnValue("Title");
+        getComponentResourceValue.mockReturnValue("Should not be used");
         hasMissingTextResources.mockReturnValue([]);
         hasValidationMessages.mockReturnValue(false);
 
-        const props = {
-            resourceValues: { utfallType: "NO" }
-        };
+        const props = {};
         const instance = new CustomGroupUtfallSvarType(props);
 
         expect(instance.isEmpty).toBe(false);
         expect(instance.resourceValues.data).toBe("Some value");
     });
 
-    it("should set resourceValues.title to undefined if hideTitle is true", () => {
-        getComponentDataValue.mockReturnValue("Value");
+    it("should set validationMessages and hasValidationMessages correctly", () => {
+        getComponentDataValue.mockReturnValue("data");
         hasValue.mockReturnValue(true);
-        getTextResourceFromResourceBinding.mockReturnValue("Should not be used");
-        hasMissingTextResources.mockReturnValue([]);
-        hasValidationMessages.mockReturnValue(false);
-
-        const props = {
-            resourceValues: { utfallType: "YES" },
-            hideTitle: true
-        };
-        const instance = new CustomGroupUtfallSvarType(props);
-
-        expect(instance.resourceValues.title).toBeUndefined();
-    });
-
-    it("should call getValidationMessages and set validationMessages and hasValidationMessages", () => {
-        getComponentDataValue.mockReturnValue("Value");
-        hasValue.mockReturnValue(true);
-        getTextResourceFromResourceBinding.mockReturnValue("Title");
-        getTextResources.mockReturnValue(["resource1", "resource2"]);
         hasMissingTextResources.mockReturnValue(["Missing resource"]);
         hasValidationMessages.mockReturnValue(true);
 
-        const props = {
-            resourceValues: { utfallType: "YES" }
-        };
+        const props = {};
         const instance = new CustomGroupUtfallSvarType(props);
 
         expect(instance.validationMessages).toEqual(["Missing resource"]);
         expect(instance.hasValidationMessages).toBe(true);
     });
 
-    it("getResourceBindings should generate correct resource key", () => {
-        const props = {
-            resourceValues: { utfallType: "YES" }
-        };
+    it("should generate correct resourceBindings for utfallType", () => {
+        getComponentDataValue.mockReturnValue("data");
+        hasValue.mockReturnValue(true);
+        hasMissingTextResources.mockReturnValue([]);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = { resourceValues: { utfallType: "YES" } };
         const instance = new CustomGroupUtfallSvarType(props);
-        const bindings = instance.getResourceBindings(props);
-        expect(bindings.utfallSvarType.title).toBe("resource.utfallBesvarelse.utfallSvar.yes.header");
+
+        expect(instance.resourceBindings.title).toBe("resource.utfallBesvarelse.utfallSvar.yes.header");
     });
 
     it("hasContent should delegate to hasValue", () => {
         hasValue.mockReturnValue(true);
-        const props = {};
-        const instance = new CustomGroupUtfallSvarType(props);
-        expect(instance.hasContent("data")).toBe(true);
-        expect(hasValue).toHaveBeenCalledWith("data");
+        const instance = new CustomGroupUtfallSvarType({});
+        expect(instance.hasContent("abc")).toBe(true);
+        expect(hasValue).toHaveBeenCalledWith("abc");
     });
 
-    it("getValueFromFormData should delegate to getComponentDataValue", () => {
-        getComponentDataValue.mockReturnValue("formData");
-        const props = {};
-        const instance = new CustomGroupUtfallSvarType(props);
-        expect(instance.getValueFromFormData(props)).toBe("formData");
+    it("getValidationMessages should call hasMissingTextResources with textResources and resourceBindings", () => {
+        getTextResources.mockReturnValue({ a: 1 });
+        hasMissingTextResources.mockReturnValue("msg");
+        const instance = new CustomGroupUtfallSvarType({});
+        const result = instance.getValidationMessages({ foo: "bar" });
+        expect(getTextResources).toHaveBeenCalled();
+        expect(hasMissingTextResources).toHaveBeenCalledWith({ a: 1 }, { foo: "bar" });
+        expect(result).toBe("msg");
+    });
+
+    it("getValueFromFormData should call getComponentDataValue with props", () => {
+        getComponentDataValue.mockReturnValue("data");
+        const instance = new CustomGroupUtfallSvarType({});
+        const props = { some: "prop" };
+        expect(instance.getValueFromFormData(props)).toBe("data");
         expect(getComponentDataValue).toHaveBeenCalledWith(props);
     });
 
-    it("getValidationMessages should delegate to hasMissingTextResources", () => {
-        getTextResources.mockReturnValue(["resource1"]);
-        hasMissingTextResources.mockReturnValue(["msg"]);
+    it("getResourceBindings should generate correct keys", () => {
+        const instance = new CustomGroupUtfallSvarType({});
+        const props = { resourceValues: { utfallType: "NO" } };
+        const result = instance.getResourceBindings(props);
+        expect(result.utfallSvarType.title).toBe("resource.utfallBesvarelse.utfallSvar.no.header");
+    });
+
+    it("getResourceBindings should handle missing utfallType gracefully", () => {
+        const instance = new CustomGroupUtfallSvarType({});
         const props = {};
-        const instance = new CustomGroupUtfallSvarType(props);
-        const bindings = { utfallSvarType: { title: "key" } };
-        expect(instance.getValidationMessages(bindings)).toEqual(["msg"]);
-        expect(getTextResources).toHaveBeenCalled();
-        expect(hasMissingTextResources).toHaveBeenCalledWith(["resource1"], bindings);
+        const result = instance.getResourceBindings(props);
+        expect(result.utfallSvarType.title).toBe("resource.utfallBesvarelse.utfallSvar.undefined.header");
     });
 });

--- a/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.js
@@ -2,32 +2,44 @@
 import CustomComponent from "../CustomComponent.js";
 
 // Global functions
-import { getComponentDataValue, getComponentResourceValue, getTextResources, hasValue } from "../../../functions/helpers.js";
-import { hasMissingTextResources } from "../../../functions/validations.js";
+import { getComponentDataValue, getTextResourceFromResourceBinding, getTextResources, hasValue } from "../../../functions/helpers.js";
+import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
 /**
- * CustomGrouplistUtfallSvar is a custom component class that handles the display and validation
- * of grouped list answers in a form. It determines if the component's data is empty, manages
- * resource values for display, and provides validation message retrieval.
+ * CustomGrouplistUtfallSvar is a custom component class for handling group list responses with resource bindings and validation.
  *
  * @extends CustomComponent
  *
- * @class
- * @param {Object} props - The properties containing form data and component information.
+ * @param {Object} props - The properties for the component, including form data and resource bindings.
+ * @param {Object} props.resourceBindings - Resource bindings for the component.
+ * @param {string} [props.resourceBindings.title] - Title resource binding.
+ * @param {string} [props.resourceBindings.emptyFieldText] - Empty field text resource binding.
+ * @param {boolean|string} [props.hideTitle] - If true or "true", hides the title.
+ * @param {boolean|string} [props.hideIfEmpty] - If true or "true", hides the empty field text.
  *
- * @property {boolean} isEmpty - Indicates whether the component's data is empty.
- * @property {Object} resourceValues - Contains resource values for display, such as empty field text or data.
+ * @property {boolean} isEmpty - Indicates if the component data is empty.
+ * @property {Array|string|boolean} validationMessages - Validation messages for the component.
+ * @property {boolean} hasValidationMessages - Indicates if there are validation messages.
+ * @property {Object} resourceValues - Contains resolved text resources for title and data.
+ * @property {string} resourceValues.title - The resolved title text resource.
+ * @property {*} resourceValues.data - The resolved data or empty field text resource.
  */
+
 export default class CustomGrouplistUtfallSvar extends CustomComponent {
     constructor(props) {
         super(props);
         const data = this.getValueFromFormData(props);
+        const resourceBindings = this.getResourceBindings(props);
 
         const isEmpty = !this.hasContent(data);
+        const validationMessages = this.getValidationMessages(resourceBindings);
 
         this.isEmpty = isEmpty;
+        this.validationMessages = validationMessages;
+        this.hasValidationMessages = hasValidationMessages(validationMessages);
         this.resourceValues = {
-            data: isEmpty ? getComponentResourceValue(props, "emptyFieldText") : data
+            title: getTextResourceFromResourceBinding(resourceBindings?.utfallSvar?.title),
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.utfallSvar?.emptyFieldText) : data
         };
     }
 
@@ -61,5 +73,29 @@ export default class CustomGrouplistUtfallSvar extends CustomComponent {
      */
     getValueFromFormData(props) {
         return getComponentDataValue(props);
+    }
+
+    /**
+     * Generates resource bindings for the component based on provided props.
+     *
+     * @param {Object} props - The properties object.
+     * @param {Object} [props.resourceBindings] - Resource bindings for the component.
+     * @param {string} [props.resourceBindings.title] - Title resource binding.
+     * @param {string} [props.resourceBindings.emptyFieldText] - Empty field text resource binding.
+     * @param {boolean|string} [props.hideTitle] - If true or "true", hides the title.
+     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", hides the empty field text.
+     * @returns {Object} An object containing the resource bindings for 'utfallSvar'.
+     */
+    getResourceBindings(props) {
+        const resourceBindings = {};
+        if (!props?.hideTitle === true || !props?.hideTitle === "true") {
+            resourceBindings.title = props?.resourceBindings?.title;
+        }
+        if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
+            resourceBindings.emptyFieldText = props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default";
+        }
+        return {
+            utfallSvar: resourceBindings
+        };
     }
 }

--- a/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.test.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.test.js
@@ -1,80 +1,230 @@
-import CustomGrouplistUtfallSvar from './CustomGrouplistUtfallSvar';
-import CustomComponent from '../CustomComponent';
-const { hasMissingTextResources } = require('../../../functions/validations.js');
+import CustomGrouplistUtfallSvar from "./CustomGrouplistUtfallSvar";
+import { getComponentDataValue, getTextResourceFromResourceBinding, getTextResources, hasValue } from "../../../functions/helpers.js";
+import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
 
-// Mock dependencies
-jest.mock('../../../functions/helpers.js', () => ({
+// Mocks for dependencies
+jest.mock("../CustomComponent.js", () => {
+    return class {};
+});
+jest.mock("../../../functions/helpers.js", () => ({
     getComponentDataValue: jest.fn(),
-    getComponentResourceValue: jest.fn(),
+    getTextResourceFromResourceBinding: jest.fn(),
     getTextResources: jest.fn(),
-    hasValue: jest.fn(),
+    hasValue: jest.fn()
 }));
-jest.mock('../../../functions/validations.js', () => ({
+jest.mock("../../../functions/validations.js", () => ({
     hasMissingTextResources: jest.fn(),
+    hasValidationMessages: jest.fn()
 }));
 
-const {
-    getComponentDataValue,
-    getComponentResourceValue,
-    getTextResources,
-    hasValue,
-} = require('../../../functions/helpers.js');
-
-describe('CustomGrouplistUtfallSvar', () => {
-    let props;
-
+describe("CustomGrouplistUtfallSvar", () => {
     beforeEach(() => {
-        props = { some: 'prop' };
         jest.clearAllMocks();
     });
 
-    it('should extend CustomComponent', () => {
-        const instance = new CustomGrouplistUtfallSvar(props);
-        expect(instance instanceof CustomComponent).toBe(true);
-    });
-
-    it('should set isEmpty to true if data is empty', () => {
+    it("should set isEmpty to true when data has no value", () => {
         getComponentDataValue.mockReturnValue(undefined);
         hasValue.mockReturnValue(false);
-        getComponentResourceValue.mockReturnValue('Empty text');
+        getTextResourceFromResourceBinding.mockImplementation((key) => `text:${key}`);
+        getTextResources.mockReturnValue(["resource1", "resource2"]);
+        hasMissingTextResources.mockReturnValue([]);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = {
+            resourceBindings: {
+                title: "titleKey",
+                emptyFieldText: "emptyFieldKey"
+            }
+        };
+
         const instance = new CustomGrouplistUtfallSvar(props);
+
         expect(instance.isEmpty).toBe(true);
-        expect(instance.resourceValues.data).toBe('Empty text');
+        expect(instance.resourceValues.title).toBe("text:titleKey");
+        expect(instance.resourceValues.data).toBe("text:emptyFieldKey");
     });
 
-    it('should set isEmpty to false if data has value', () => {
-        getComponentDataValue.mockReturnValue('Some data');
+    it("should set isEmpty to false when data has value", () => {
+        getComponentDataValue.mockReturnValue("someData");
         hasValue.mockReturnValue(true);
+        getTextResourceFromResourceBinding.mockImplementation((key) => `text:${key}`);
+        getTextResources.mockReturnValue(["resource1", "resource2"]);
+        hasMissingTextResources.mockReturnValue([]);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = {
+            resourceBindings: {
+                title: "titleKey",
+                emptyFieldText: "emptyFieldKey"
+            }
+        };
+
         const instance = new CustomGrouplistUtfallSvar(props);
+
         expect(instance.isEmpty).toBe(false);
-        expect(instance.resourceValues.data).toBe('Some data');
+        expect(instance.resourceValues.data).toBe("someData");
     });
 
-    it('hasContent should return result of hasValue', () => {
+    it("should hide title if hideTitle is true", () => {
+        getComponentDataValue.mockReturnValue("someData");
         hasValue.mockReturnValue(true);
+        getTextResourceFromResourceBinding.mockImplementation((key) => `text:${key}`);
+        getTextResources.mockReturnValue(["resource1", "resource2"]);
+        hasMissingTextResources.mockReturnValue([]);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = {
+            resourceBindings: {
+                title: "titleKey",
+                emptyFieldText: "emptyFieldKey"
+            },
+            hideTitle: true
+        };
+
         const instance = new CustomGrouplistUtfallSvar(props);
-        expect(instance.hasContent('abc')).toBe(true);
+
+        expect(instance.resourceValues.title).toBe("text:undefined");
+    });
+
+    it("should use default emptyFieldText if not provided and hideIfEmpty is not true", () => {
+        getComponentDataValue.mockReturnValue(undefined);
         hasValue.mockReturnValue(false);
-        expect(instance.hasContent('')).toBe(false);
+        getTextResourceFromResourceBinding.mockImplementation((key) => `text:${key}`);
+        getTextResources.mockReturnValue(["resource1", "resource2"]);
+        hasMissingTextResources.mockReturnValue([]);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = {
+            resourceBindings: {
+                title: "titleKey"
+            }
+        };
+
+        const instance = new CustomGrouplistUtfallSvar(props);
+
+        expect(instance.resourceValues.data).toBe("text:resource.emptyFieldText.default");
     });
 
-    it('getValidationMessages should call hasMissingTextResources with textResources and resourceBindings', () => {
-        const resourceBindings = { key: 'value' };
-        const textResources = [{ id: '1', value: 'Test' }];
-        getTextResources.mockReturnValue(textResources);
-        hasMissingTextResources.mockReturnValue(['missing']);
+    it("should not set emptyFieldText if hideIfEmpty is true", () => {
+        getComponentDataValue.mockReturnValue(undefined);
+        hasValue.mockReturnValue(false);
+        getTextResourceFromResourceBinding.mockImplementation((key) => `text:${key}`);
+        getTextResources.mockReturnValue(["resource1", "resource2"]);
+        hasMissingTextResources.mockReturnValue([]);
+        hasValidationMessages.mockReturnValue(false);
+
+        const props = {
+            resourceBindings: {
+                title: "titleKey",
+                emptyFieldText: "emptyFieldKey"
+            },
+            hideIfEmpty: true
+        };
+
         const instance = new CustomGrouplistUtfallSvar(props);
-        const result = instance.getValidationMessages(resourceBindings);
-        expect(getTextResources).toHaveBeenCalled();
-        expect(hasMissingTextResources).toHaveBeenCalledWith(textResources, resourceBindings);
-        expect(result).toEqual(['missing']);
+
+        expect(instance.resourceValues.data).toBe("text:undefined");
     });
 
-    it('getValueFromFormData should call getComponentDataValue with props', () => {
-        getComponentDataValue.mockReturnValue('data');
+    it("should call hasValidationMessages and set validationMessages", () => {
+        getComponentDataValue.mockReturnValue("someData");
+        hasValue.mockReturnValue(true);
+        getTextResourceFromResourceBinding.mockImplementation((key) => `text:${key}`);
+        getTextResources.mockReturnValue(["resource1", "resource2"]);
+        hasMissingTextResources.mockReturnValue(["missingKey"]);
+        hasValidationMessages.mockReturnValue(true);
+
+        const props = {
+            resourceBindings: {
+                title: "titleKey",
+                emptyFieldText: "emptyFieldKey"
+            }
+        };
+
         const instance = new CustomGrouplistUtfallSvar(props);
-        const result = instance.getValueFromFormData(props);
-        expect(getComponentDataValue).toHaveBeenCalledWith(props);
-        expect(result).toBe('data');
+
+        expect(instance.validationMessages).toEqual(["missingKey"]);
+        expect(instance.hasValidationMessages).toBe(true);
+    });
+
+    describe("hasContent", () => {
+        it("should return result of hasValue", () => {
+            hasValue.mockReturnValue(true);
+            const instance = new CustomGrouplistUtfallSvar({});
+            expect(instance.hasContent("data")).toBe(true);
+
+            hasValue.mockReturnValue(false);
+            expect(instance.hasContent("")).toBe(false);
+        });
+    });
+
+    describe("getValidationMessages", () => {
+        it("should call hasMissingTextResources with textResources and resourceBindings", () => {
+            getTextResources.mockReturnValue(["resource1"]);
+            hasMissingTextResources.mockReturnValue(["missing"]);
+            const instance = new CustomGrouplistUtfallSvar({});
+            const result = instance.getValidationMessages({ foo: "bar" });
+            expect(getTextResources).toHaveBeenCalled();
+            expect(hasMissingTextResources).toHaveBeenCalledWith(["resource1"], { foo: "bar" });
+            expect(result).toEqual(["missing"]);
+        });
+    });
+
+    describe("getValueFromFormData", () => {
+        it("should call getComponentDataValue with props", () => {
+            getComponentDataValue.mockReturnValue("value");
+            const instance = new CustomGrouplistUtfallSvar({});
+            const result = instance.getValueFromFormData({ foo: "bar" });
+            expect(getComponentDataValue).toHaveBeenCalledWith({ foo: "bar" });
+            expect(result).toBe("value");
+        });
+    });
+
+    describe("getResourceBindings", () => {
+        it("should include title and emptyFieldText when not hidden", () => {
+            const instance = new CustomGrouplistUtfallSvar({});
+            const props = {
+                resourceBindings: {
+                    title: "titleKey",
+                    emptyFieldText: "emptyFieldKey"
+                }
+            };
+            const result = instance.getResourceBindings(props);
+            expect(result.utfallSvar.title).toBe("titleKey");
+            expect(result.utfallSvar.emptyFieldText).toBe("emptyFieldKey");
+        });
+
+        it("should not include title when hideTitle is true", () => {
+            const instance = new CustomGrouplistUtfallSvar({});
+            const props = {
+                resourceBindings: {
+                    title: "titleKey"
+                },
+                hideTitle: true
+            };
+            const result = instance.getResourceBindings(props);
+            expect(result.utfallSvar.title).toBeUndefined();
+        });
+
+        it("should use default emptyFieldText when not provided", () => {
+            const instance = new CustomGrouplistUtfallSvar({});
+            const props = {
+                resourceBindings: {}
+            };
+            const result = instance.getResourceBindings(props);
+            expect(result.utfallSvar.emptyFieldText).toBe("resource.emptyFieldText.default");
+        });
+
+        it("should not include emptyFieldText when hideIfEmpty is true", () => {
+            const instance = new CustomGrouplistUtfallSvar({});
+            const props = {
+                resourceBindings: {
+                    emptyFieldText: "emptyFieldKey"
+                },
+                hideIfEmpty: true
+            };
+            const result = instance.getResourceBindings(props);
+            expect(result.utfallSvar.emptyFieldText).toBeUndefined();
+        });
     });
 });

--- a/src/components/data-components/custom-grouplist-ettersending/index.js
+++ b/src/components/data-components/custom-grouplist-ettersending/index.js
@@ -25,9 +25,9 @@ export default customElements.define(
                     const dividerElement = createCustomElement("custom-divider");
                     this.appendChild(dividerElement);
                 }
-                const feebackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-                if (feebackListElement) {
-                    this.appendChild(feebackListElement);
+                const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+                if (feedbackListElement) {
+                    this.appendChild(feedbackListElement);
                 }
             }
         }

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/index.js
@@ -1,9 +1,10 @@
 // Global functions
 import { createCustomElement, getComponentContainerElement } from "../../../../../functions/helpers.js";
 import { instantiateComponent } from "../../../../../functions/componentHelpers.js";
+import { renderFeedbackListElement } from "../../../../../functions/feedbackHelpers.js";
 
 // Local functions
-import { renderUtfallSvarGroup } from "./renderers.js";
+import { renderEmptyFieldText, renderHeaderElement, renderUtfallSvarGroup } from "./renderers.js";
 
 export default customElements.define(
     "custom-grouplist-utfall-svar",
@@ -13,12 +14,20 @@ export default customElements.define(
             const componentContainerElement = getComponentContainerElement(this);
             if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
                 componentContainerElement.style.display = "none";
+            } else if (component?.isEmpty) {
+                const emptyFieldTextElement = renderEmptyFieldText(component);
+                this.appendChild(emptyFieldTextElement);
             } else {
+                this.appendChild(renderHeaderElement(component, "h2"));
                 for (const utfallSvar of component?.resourceValues?.data) {
                     const utfallSvarElement = renderUtfallSvarGroup(utfallSvar);
                     this.appendChild(utfallSvarElement);
                     const dividerElement = createCustomElement("custom-divider");
                     this.appendChild(dividerElement);
+                }
+                const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+                if (feedbackListElement) {
+                    this.appendChild(feedbackListElement);
                 }
             }
         }

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/renderers.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/renderers.js
@@ -5,6 +5,24 @@ import CustomElementHtmlAttributes from "../../../../../classes/system-classes/C
 import { createCustomElement } from "../../../../../functions/helpers.js";
 
 /**
+ * Renders a custom header element for a given component.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {string} [size="h2"] - The size of the header element (e.g., "h1", "h2", etc.).
+ * @returns {HTMLElement} The created custom header element.
+ */
+export function renderHeaderElement(component, size = "h2") {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        size,
+        resourceValues: {
+            title: component?.resourceValues?.title
+        }
+    });
+    return createCustomElement("custom-header-text", htmlAttributes);
+}
+
+/**
  * Renders a custom group element for "utfallSvar" data.
  *
  * @param {Object} utfallSvar - The data to be rendered within the custom group component.
@@ -19,4 +37,22 @@ export function renderUtfallSvarGroup(utfallSvar) {
         }
     });
     return createCustomElement("custom-group-utfall-svar", htmlAttributes);
+}
+
+/**
+ * Renders a custom paragraph element displaying the empty field text for a given component.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {string} [component.resourceValues.data] - The text to display as the empty field.
+ * @returns {HTMLElement} The custom paragraph element with the specified attributes.
+ */
+export function renderEmptyFieldText(component) {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        resourceValues: {
+            title: component?.resourceValues?.data
+        }
+    });
+    return createCustomElement("custom-paragraph", htmlAttributes);
 }

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/index.js
@@ -3,7 +3,7 @@ import { instantiateComponent } from "../../../../functions/componentHelpers.js"
 import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
 
 // Local functions
-import { renderHeader, renderUtfallSvarGroupList } from "./renderers.js";
+import { renderUtfallSvarGroupList } from "./renderers.js";
 
 export default customElements.define(
     "custom-group-utfall-svar-type",
@@ -11,8 +11,6 @@ export default customElements.define(
         async connectedCallback() {
             const component = instantiateComponent(this);
             if (!component.isEmpty) {
-                const headerElement = renderHeader(component);
-                this.appendChild(headerElement);
                 const utfallSvarGroupListElement = renderUtfallSvarGroupList(component);
                 this.appendChild(utfallSvarGroupListElement);
 

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/renderers.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/renderers.js
@@ -5,24 +5,6 @@ import CustomElementHtmlAttributes from "../../../../classes/system-classes/Cust
 import { createCustomElement } from "../../../../functions/helpers.js";
 
 /**
- * Renders a custom header element for a given component.
- *
- * @param {Object} component - The component object containing resource values.
- * @param {string} [size="h2"] - The header size (e.g., "h1", "h2", etc.).
- * @returns {HTMLElement} The created custom header element.
- */
-export function renderHeader(component, size = "h2") {
-    const htmlAttributes = new CustomElementHtmlAttributes({
-        isChildComponent: true,
-        size,
-        resourceValues: {
-            title: component?.resourceValues?.title
-        }
-    });
-    return createCustomElement("custom-header-text", htmlAttributes);
-}
-
-/**
  * Renders a custom group list component for "Utfall Svar" type.
  *
  * @param {Object} component - The component configuration object.
@@ -33,8 +15,12 @@ export function renderHeader(component, size = "h2") {
 export function renderUtfallSvarGroupList(component) {
     const htmlAttributes = new CustomElementHtmlAttributes({
         isChildComponent: true,
+        resourceBindings: {
+            title: component?.resourceBindings?.title
+        },
         resourceValues: {
-            data: component?.resourceValues?.data
+            data: component?.resourceValues?.data,
+            title: component?.resourceValues?.title
         }
     });
     return createCustomElement("custom-grouplist-utfall-svar", htmlAttributes);


### PR DESCRIPTION
Refactor group list components to handle empty states and validations.

This pull request refactors `CustomGrouplistUtfallSvar` and `CustomGroupUtfallSvarType` to improve handling of empty states, validation messages, and resource bindings. It also adjusts component rendering to conditionally display content based on data availability and validation status.

### Changes

- Modified `CustomGrouplistUtfallSvar`:
  - Added validation message handling (`validationMessages` and `hasValidationMessages`).
  - Implemented `getResourceBindings` to handle `title` and `emptyFieldText` resource bindings, including conditional logic based on `hideTitle` and `hideIfEmpty` props.
  - Updated constructor to use `getTextResourceFromResourceBinding` for retrieving resource values and `hasValidationMessages` for validation status.
- Modified `CustomGroupUtfallSvarType`:
  - Simplified resource value assignments.
  - Introduced `resourceBindings` property to store `title` resource binding.
- Modified `CustomGroupUtfallSvar`:
  - Changed `getValueFromFormData` to return a `UtfallSvar` object.
- Modified component rendering in:
  - `custom-grouplist-ettersending/index.js` to use `feedbackListElement` instead of `feebackListElement`.
  - `custom-grouplist-utfall-svar/index.js` to render empty field text when `isEmpty` is true and the component is not hidden, also renders header.
- Removed `renderHeader` function from `custom-group-utfall-svar-type/index.js` and `custom-group-utfall-svar-type/renderers.js`.
- Updated tests to reflect the above changes, including mocking new functions and testing new logic.

### Impact

- Improved handling of empty states: Components now conditionally render content or empty field text based on the `isEmpty` property.
- Enhanced validation handling: Components now display validation messages using `renderFeedbackListElement`.
- Refactored resource binding logic: The `getResourceBindings` method in `CustomGrouplistUtfallSvar` provides a centralized way to manage resource bindings.
- The change in `CustomGroupUtfallSvar` to return an `UtfallSvar` object may affect any components that rely on the previous return type.
