### PR TITLE
Hotfix/fix style override for text components

### DIFF
--- a/src/components/base-components/custom-header/index.js
+++ b/src/components/base-components/custom-header/index.js
@@ -16,7 +16,7 @@ export default customElements.define(
         connectedCallback() {
             const component = instantiateComponent(this);
             if (!component?.isEmpty) {
-                this.innerHTML = renderHeaderElement(component?.resourceValues?.title, component?.size);
+                this.innerHTML = renderHeaderElement(component);
                 addStyle(this, component?.styleOverride);
             }
         }

--- a/src/components/base-components/custom-header/renderers.js
+++ b/src/components/base-components/custom-header/renderers.js
@@ -1,16 +1,24 @@
 // Global functions
 import { isValidHeaderSize } from "../../../functions/dataFormatHelpers.js";
+import { addStyle } from "../../../functions/helpers.js";
 
 /**
- * Renders a header element with the specified text, size, and optional style overrides.
+ * Renders a header HTML element based on the provided component configuration.
  *
- * @param {string} text - The text content to be displayed in the header element.
- * @param {string} [size] - The size of the header element (e.g., 'h1', 'h2'). Defaults to a predefined size if not provided.
- * @returns {string} The outer HTML of the created header element.
+ * @param {Object} component - The component configuration object.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {string} [component.resourceValues.title] - The text to display in the header.
+ * @param {string} [component.size] - The desired header size (e.g., "h1", "h2", etc.).
+ * @param {Object} [component.styleOverride] - Optional style overrides for the header element.
+ * @returns {string} The outer HTML string of the rendered header element.
  */
-export function renderHeaderElement(text, size) {
+export function renderHeaderElement(component) {
+    const text = component?.resourceValues?.title;
     const defaultHeaderSize = "h2";
+    const size = component?.size;
+    const styleOverride = component?.styleOverride;
     const headerElement = document.createElement(isValidHeaderSize(size) ? size : defaultHeaderSize);
     headerElement.innerHTML = text;
+    addStyle(headerElement, styleOverride);
     return headerElement.outerHTML;
 }

--- a/src/components/base-components/custom-paragraph/index.js
+++ b/src/components/base-components/custom-paragraph/index.js
@@ -1,5 +1,4 @@
 // Global functions
-import { addStyle } from "../../../functions/helpers.js";
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
 
 // Local functions
@@ -14,8 +13,8 @@ export default customElements.define(
         connectedCallback() {
             const component = instantiateComponent(this);
             if (!component?.isEmpty) {
-                this.innerHTML = renderParagraphElement(component?.resourceValues?.title);
-                addStyle(this, component?.styleOverride);
+                const paragraphElement = renderParagraphElement(component);
+                this.innerHTML = paragraphElement;
             }
         }
     }

--- a/src/components/base-components/custom-paragraph/renderers.js
+++ b/src/components/base-components/custom-paragraph/renderers.js
@@ -1,11 +1,20 @@
+// Global functions
+import { addStyle } from "../../../functions/helpers.js";
+
 /**
- * Renders a paragraph element with the specified text and optional style overrides.
+ * Renders a paragraph HTML element with the specified text and style overrides.
  *
- * @param {string} text - The text content to be displayed in the paragraph element.
- * @returns {string} The outer HTML of the created paragraph element.
+ * @param {Object} component - The component object containing paragraph data.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {string} [component.resourceValues.title] - The text to display in the paragraph.
+ * @param {Object} [component.styleOverride] - Optional style overrides to apply to the paragraph element.
+ * @returns {string} The outer HTML string of the rendered paragraph element.
  */
-export function renderParagraphElement(text) {
+export function renderParagraphElement(component) {
+    const text = component?.resourceValues?.title;
+    const styleOverride = component?.styleOverride;
     const paragraphElement = document.createElement("p");
     paragraphElement.innerHTML = text;
+    addStyle(paragraphElement, styleOverride);
     return paragraphElement.outerHTML;
 }


### PR DESCRIPTION
Refactor: Header rendering for component-based configuration.

The `renderHeaderElement` function now accepts a component object instead of individual text and size parameters. This change allows for more flexible header rendering, enabling the function to access component properties like `title`, `size`, and `styleOverride`.

### Changes

- Modified the `renderHeaderElement` function in `src/components/base-components/custom-header/renderers.js` to accept a component object as input.
- The `renderHeaderElement` function now extracts the `title` and `size` from the component object.
- The custom header component in `src/components/base-components/custom-header/index.js` is updated to pass the whole component to the `renderHeaderElement` function.
- Included `addStyle` in `renderHeaderElement` to allow styling of the element via javascript.

### Impact

The `renderHeaderElement` function is more flexible and can access more component properties.
The change promotes a component-driven approach to header rendering.
Dependencies: `addStyle` is now a dependency.
