### PR TITLE
Feature/improve screen reader support

### DIFF
--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -1,16 +1,21 @@
 // Global functions
 import { injectAnchorElements } from "../../../functions/dataFormatHelpers.js";
-import { addStyle, hasValue } from "../../../functions/helpers.js";
+import { addStyle, generateUniqueId, hasValue } from "../../../functions/helpers.js";
 
 /**
- * Renders a field title element as a label.
+ * Creates and returns a span element representing a field title.
  *
- * @param {string} fieldTitle - The title text to be displayed in the label.
- * @param {boolean} inline - A flag indicating whether the title should be displayed inline with a colon.
- * @returns {HTMLLabelElement} The created label element with the specified title.
+ * @param {string} fieldTitle - The text to display as the field title.
+ * @param {string} [fieldTitleId] - Optional ID to assign to the span element.
+ * @param {boolean} inline - If true, appends a colon to the field title.
+ * @returns {HTMLSpanElement} The span element containing the field title.
  */
-function renderFieldTitleElement(fieldTitle, inline) {
-    const fieldTitleLabelElement = document.createElement("label");
+function renderFieldTitleElement(fieldTitle, fieldTitleId, inline) {
+    const fieldTitleLabelElement = document.createElement("span");
+    if (fieldTitleId) {
+        fieldTitleLabelElement.id = fieldTitleId;
+    }
+    fieldTitleLabelElement.classList.add("field-title");
     fieldTitleLabelElement.innerText = `${fieldTitle}${inline ? ":" : ""}`;
     return fieldTitleLabelElement;
 }
@@ -29,6 +34,7 @@ function renderFieldTitleElement(fieldTitle, inline) {
  */
 function renderFieldValueElement(fieldValue, enableLinks) {
     const fieldValueElement = document.createElement("span");
+    fieldValueElement.classList.add("field-value");
     if (Array.isArray(fieldValue)) {
         fieldValue = fieldValue.join(", ");
     }
@@ -44,16 +50,16 @@ function renderFieldValueElement(fieldValue, enableLinks) {
 }
 
 /**
- * Renders a field element with a title and value.
+ * Renders a custom field element with a title and value, supporting various options.
  *
- * @param {string} fieldTitle - The title of the field.
- * @param {string} fieldValue - The value of the field.
- * @param {Object} [options] - Optional settings for rendering the field element.
- * @param {boolean} [options.returnHtml=true] - Whether to return the element as HTML string.
- * @param {boolean} [options.inline=false] - Whether to render the field inline.
- * @param {Object} [options.styleOverride={}] - Custom styles to apply to the field element.
- * @param {boolean} [options.enableLinks=false] - Whether to enable links in the field value.
- * @returns {HTMLElement|string} The rendered field element or its HTML string representation.
+ * @param {string} fieldTitle - The title of the field to display.
+ * @param {*} fieldValue - The value/content of the field to display.
+ * @param {Object} [options] - Optional settings for rendering the field.
+ * @param {boolean} [options.returnHtml=true] - If true, returns the field as an HTML string; otherwise, returns the DOM element.
+ * @param {boolean} [options.inline=false] - If true, renders the field inline.
+ * @param {Object} [options.styleOverride={}] - CSS style overrides to apply to the field element.
+ * @param {boolean} [options.enableLinks] - If true, enables link rendering in the field value.
+ * @returns {string|HTMLElement} The rendered field element as an HTML string or DOM element, depending on `options.returnHtml`.
  */
 export function renderFieldElement(fieldTitle, fieldValue, options) {
     options = {
@@ -64,8 +70,9 @@ export function renderFieldElement(fieldTitle, fieldValue, options) {
     };
     const fieldElement = document.createElement("div");
     fieldElement.classList.add("field");
+    const fieldTitleId = fieldTitle?.length ? generateUniqueId("custom-field-") : null;
     if (fieldTitle?.length) {
-        fieldElement.appendChild(renderFieldTitleElement(fieldTitle, options.inline));
+        fieldElement.appendChild(renderFieldTitleElement(fieldTitle, fieldTitleId, options.inline));
     }
     if (options?.inline) {
         fieldElement.classList.add("inline");
@@ -73,6 +80,7 @@ export function renderFieldElement(fieldTitle, fieldValue, options) {
     const fieldValueElement = renderFieldValueElement(fieldValue, options.enableLinks);
     if (fieldTitle?.length) {
         fieldValueElement.classList.add("has-title");
+        fieldValueElement.setAttribute("aria-labelledby", fieldTitleId);
     }
     fieldElement.appendChild(fieldValueElement);
     addStyle(fieldElement, {

--- a/src/components/base-components/custom-field/styles.css
+++ b/src/components/base-components/custom-field/styles.css
@@ -11,7 +11,7 @@ custom-field {
             flex-direction: row;
             gap: 0.5rem;
         }
-        & label {
+        & span.field-title {
             font-weight: bold;
             display: block;
             page-break-after: avoid;
@@ -23,7 +23,7 @@ custom-field {
                 margin-bottom: -50px;
             }
         }
-        & span {
+        & span.field-value {
             white-space: pre-line;
             display: block;
             & a {
@@ -31,7 +31,7 @@ custom-field {
             }
         }
         &:not(.inline) {
-            & span {
+            & span.field-value {
                 &.has-title {
                     page-break-before: avoid;
                 }

--- a/src/components/base-components/custom-list/renderers.js
+++ b/src/components/base-components/custom-list/renderers.js
@@ -1,11 +1,19 @@
+// Global functions
+import { generateUniqueId } from "../../../functions/helpers.js";
+
 /**
- * Creates a label element with the specified field title as its inner text.
+ * Creates a span element representing a field title with a specific class and optional ID.
  *
- * @param {string} fieldTitle - The title to be set as the inner text of the label element.
- * @returns {HTMLLabelElement} The created label element with the specified field title.
+ * @param {string} fieldTitle - The text content for the field title.
+ * @param {string} [fieldTitleId] - Optional ID to assign to the span element.
+ * @returns {HTMLSpanElement} The created span element with the field title.
  */
-function renderFieldTitleElement(fieldTitle) {
-    const fieldTitleLabelElement = document.createElement("label");
+function renderFieldTitleElement(fieldTitle, fieldTitleId) {
+    const fieldTitleLabelElement = document.createElement("span");
+    if (fieldTitleId) {
+        fieldTitleLabelElement.id = fieldTitleId;
+    }
+    fieldTitleLabelElement.classList.add("field-title");
     fieldTitleLabelElement.innerText = fieldTitle;
     return fieldTitleLabelElement;
 }
@@ -29,22 +37,24 @@ export function renderListElement(listItems, listType, returnHtml = true) {
 }
 
 /**
- * Renders a list field element with an optional title.
+ * Renders a list field element with an optional title and list items.
  *
- * @param {string} fieldTitle - The title of the field.
- * @param {Array} listItems - The items to be included in the list.
- * @param {string} listType - The type of the list (e.g., 'ul' for unordered list, 'ol' for ordered list).
- * @returns {string} The outer HTML of the rendered field element.
+ * @param {string} fieldTitle - The title of the field to display above the list. If empty or undefined, no title is rendered.
+ * @param {Array} listItems - The items to display in the list.
+ * @param {string} listType - The type of list to render (e.g., "ul" for unordered, "ol" for ordered).
+ * @returns {string} The HTML string representing the rendered field element containing the title and list.
  */
 export function renderListFieldElement(fieldTitle, listItems, listType) {
     const fieldElement = document.createElement("div");
     fieldElement.classList.add("field");
+    const fieldTitleId = fieldTitle?.length ? generateUniqueId("custom-field-") : null;
     if (fieldTitle?.length) {
-        fieldElement.appendChild(renderFieldTitleElement(fieldTitle));
+        fieldElement.appendChild(renderFieldTitleElement(fieldTitle, fieldTitleId));
     }
     const listElement = renderListElement(listItems, listType, false);
     if (fieldTitle?.length) {
         listElement.classList.add("has-title");
+        listElement.setAttribute("aria-labelledby", fieldTitleId);
     }
     fieldElement.appendChild(listElement);
     return fieldElement.outerHTML;

--- a/src/components/base-components/custom-list/styles.css
+++ b/src/components/base-components/custom-list/styles.css
@@ -5,7 +5,7 @@ custom-list {
     color: var(--color-text-default);
     line-height: var(--line-height-default);
     & .field {
-        & label {
+        & span.field-title {
             font-weight: bold;
             display: block;
             page-break-after: avoid;

--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -113,6 +113,21 @@ export function getRowNumberTitle(component) {
 }
 
 /**
+ * Generates a unique identifier string, optionally prefixed.
+ *
+ * The identifier is composed of the current timestamp (in base36)
+ * and a random string (also in base36), ensuring uniqueness.
+ *
+ * @param {string} [prefix=""] - Optional prefix to prepend to the unique ID.
+ * @returns {string} A unique identifier string.
+ */
+export function generateUniqueId(prefix = "") {
+    const timestamp = Date.now().toString(36); // base36 for compactness
+    const random = Math.random().toString(36).substring(2, 10); // skip "0."
+    return `${prefix}${timestamp}${random}`;
+}
+
+/**
  * Creates a custom HTML element with the specified tag name and attributes.
  *
  * @param {string} tagName - The name of the HTML tag to create.

--- a/src/functions/helpers.test.js
+++ b/src/functions/helpers.test.js
@@ -19,7 +19,8 @@ import {
     getComponentBooleanTextValues,
     getComponentResourceValue,
     appendChildren,
-    calculateFlexWidth
+    calculateFlexWidth,
+    generateUniqueId
 } from "./helpers";
 
 // Mock for customElementTagNames
@@ -91,6 +92,30 @@ describe("getRowNumberTitle", () => {
     });
     it("returns text resource if found", () => {
         expect(getRowNumberTitle({ resourceBindings: { rowNumberTitle: "rowTitle" } })).toBe("Row #");
+    });
+});
+
+describe("generateUniqueId", () => {
+    it("generates a unique id with no prefix", () => {
+        const id1 = generateUniqueId();
+        const id2 = generateUniqueId();
+        expect(typeof id1).toBe("string");
+        expect(typeof id2).toBe("string");
+        expect(id1).not.toBe(id2);
+        expect(id1.length).toBeGreaterThan(0);
+    });
+
+    it("generates a unique id with a prefix", () => {
+        const prefix = "test-";
+        const id = generateUniqueId(prefix);
+        expect(id.startsWith(prefix)).toBe(true);
+        expect(id.length).toBeGreaterThan(prefix.length);
+    });
+
+    it("ids generated in quick succession are different", () => {
+        const ids = Array.from({ length: 5 }, () => generateUniqueId());
+        const uniqueIds = new Set(ids);
+        expect(uniqueIds.size).toBe(ids.length);
     });
 });
 


### PR DESCRIPTION
Enhances custom field/list rendering with unique IDs and styling.

This pull request modifies custom field and list rendering to improve accessibility and styling. It introduces unique IDs for field titles and updates the CSS to target specific elements for better control.

### Changes

- Added `generateUniqueId` import to `renderers.js` in both `custom-field` and `custom-list` components.
- Modified `renderFieldTitleElement` function in both components to create a `span` element instead of a `label`, assign an optional ID, and add a `field-title` class.
- Modified `renderFieldElement` in `custom-field` and `renderListFieldElement` in `custom-list` to generate a unique ID for the field title and set `aria-labelledby` on the value/list element.
- Updated CSS files for both components to target `span.field-title` and `span.field-value` instead of generic label and span elements for styling.
- Updated JSDoc comments to reflect changes to the return types of functions to `HTMLSpanElement` and the addition of the `fieldTitleId` argument.

### Impact

- Improved accessibility by allowing the field value/list to be associated with its title using `aria-labelledby`.
- Enhanced styling capabilities by using more specific CSS selectors.
- No apparent breaking changes, as the changes are mostly additive.
- The use of `generateUniqueId` should not have any significant performance impact.
