### PR TITLE
Hotfix/fix empty summation arealdisponering handling

### DIFF
--- a/src/classes/system-classes/component-classes/CustomSummationArealdisponering.js
+++ b/src/classes/system-classes/component-classes/CustomSummationArealdisponering.js
@@ -40,7 +40,7 @@ export default class CustomSummationArealdisponering extends CustomComponent {
             emptyFieldText: resourceBindings?.emptyFieldText || undefined
         };
         this.resourceValues = {
-            data: isEmpty ? getTextResourceFromResourceBinding(props?.resourceBindings?.emptyFieldText) : data
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.emptyFieldText) : data
         };
     }
 
@@ -194,10 +194,7 @@ export default class CustomSummationArealdisponering extends CustomComponent {
             }
         };
         if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
-            resourceBindings.part = {
-                ...resourceBindings.part,
-                emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"
-            };
+            resourceBindings.emptyFieldText = props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default";
         }
         return resourceBindings;
     }

--- a/src/components/data-components/custom-summation-arealdisponering/index.js
+++ b/src/components/data-components/custom-summation-arealdisponering/index.js
@@ -6,7 +6,7 @@ import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js
 import { getComponentContainerElement } from "../../../functions/helpers.js";
 
 // Local functions
-import { renderSummationArealdisponering } from "./renderers.js";
+import { renderEmptyFieldText, renderSummationArealdisponering } from "./renderers.js";
 
 export default customElements.define(
     "custom-summation-arealdisponering",
@@ -16,6 +16,9 @@ export default customElements.define(
             const componentContainerElement = getComponentContainerElement(this);
             if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
                 componentContainerElement.style.display = "none";
+            } else if (component?.isEmpty) {
+                const emptyFieldTextElement = renderEmptyFieldText(component);
+                this.appendChild(emptyFieldTextElement);
             } else {
                 const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
                 const summationArealdisponeringElement = renderSummationArealdisponering(component);

--- a/src/components/data-components/custom-summation-arealdisponering/renderers.js
+++ b/src/components/data-components/custom-summation-arealdisponering/renderers.js
@@ -57,3 +57,21 @@ export function renderSummationArealdisponering(component) {
     }
     return null;
 }
+
+/**
+ * Renders a custom paragraph element displaying the empty field text for a given component.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {string} [component.resourceValues.data] - The text to display as the empty field.
+ * @returns {HTMLElement} The custom paragraph element with the specified attributes.
+ */
+export function renderEmptyFieldText(component) {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        resourceValues: {
+            title: component?.resourceValues?.data
+        }
+    });
+    return createCustomElement("custom-paragraph", htmlAttributes);
+}


### PR DESCRIPTION
Displays text when arealdisponering component is empty.

This pull request introduces a mechanism to display a custom paragraph element when the `custom-summation-arealdisponering` component is empty, instead of only hiding it. It adds a function to render the empty field text.

### Changes

- Added `renderEmptyFieldText` function to `src/components/data-components/custom-summation-arealdisponering/renderers.js`, which creates a `custom-paragraph` element to display empty field text using resource values.
- Modified `src/components/data-components/custom-summation-arealdisponering/index.js` to use `renderEmptyFieldText` when the component is empty but not hidden, appending the generated element to the component.

### Impact

- When a `custom-summation-arealdisponering` component has data and the `hideIfEmpty` property is `false`, the empty field text is displayed.
- The change introduces a dependency on the `createCustomElement` function through `renderEmptyFieldText` function.
- No breaking changes are apparent.
