### PR TITLE
Adds responsible applicant to dispensasjon

### DIFF
--- a/src/classes/layout-classes/Dispensasjon.js
+++ b/src/classes/layout-classes/Dispensasjon.js
@@ -28,6 +28,7 @@ export default class Dispensasjon {
      * @param {EiendomByggested} [props.eiendomByggested] - The property or construction site information.
      * @param {Tiltakstyper} [props.tiltakstyper] - The types of measures involved.
      * @param {Part} [props.tiltakshaver] - The party responsible for the tiltak (measure).
+     * @param {Part} [props.ansvarligSoeker] - The responsible applicant.
      * @param {DispensasjonFra} [props.dispensasjonFra] - Information about what the dispensasjon is from.
      * @param {Stedfesting} [props.stedfesting] - Geographical location information.
      * @param {Varighet} [props.varighet] - The duration of the dispensasjon.
@@ -43,6 +44,7 @@ export default class Dispensasjon {
         this.eiendomByggested = props?.eiendomByggested && new EiendomByggested(props.eiendomByggested);
         this.tiltakstyper = props?.tiltakstyper && new Tiltakstyper(props.tiltakstyper);
         this.tiltakshaver = props?.tiltakshaver && new Part(props.tiltakshaver);
+        this.ansvarligSoeker = props?.ansvarligSoeker && new Part(props.ansvarligSoeker);
         this.dispensasjonFra = props?.dispensasjonFra && new DispensasjonFra(props.dispensasjonFra);
         this.stedfesting = props?.stedfesting && new Stedfesting(props.stedfesting);
         this.varighet = props?.varighet && new Varighet(props.varighet);

--- a/src/classes/layout-classes/Dispensasjon.test.js
+++ b/src/classes/layout-classes/Dispensasjon.test.js
@@ -20,6 +20,7 @@ describe("Dispensasjon", () => {
             metadata: { createdBy: "user" },
             eiendomByggested: { address: "Test address" },
             tiltakshaver: { name: "Test Party" },
+            ansvarligSoeker: { name: "Test Applicant" },
             dispensasjonFra: { reason: "Test reason" },
             stedfesting: { location: "Test location" },
             varighet: { duration: "1 year" },
@@ -36,6 +37,7 @@ describe("Dispensasjon", () => {
         expect(instance.metadata).toBeInstanceOf(Metadata);
         expect(instance.eiendomByggested).toBeInstanceOf(EiendomByggested);
         expect(instance.tiltakshaver).toBeInstanceOf(Part);
+        expect(instance.ansvarligSoeker).toBeInstanceOf(Part);
         expect(instance.dispensasjonFra).toBeInstanceOf(DispensasjonFra);
         expect(instance.stedfesting).toBeInstanceOf(Stedfesting);
         expect(instance.varighet).toBeInstanceOf(Varighet);

--- a/src/classes/system-classes/component-classes/CustomDispensasjon.js
+++ b/src/classes/system-classes/component-classes/CustomDispensasjon.js
@@ -122,6 +122,9 @@ export default class CustomDispensasjon extends CustomComponent {
             tiltakshaverAdresse: {
                 title: "resource.tiltakshaver.adresse.title"
             },
+            ansvarligSoekerAdresse: {
+                title: "resource.ansvarligSoeker.adresse.title"
+            },
             dispensasjonBeskrivelseBeskrivelse: {
                 title: "resource.dispensasjonBeskrivelse.beskrivelse.title"
             },

--- a/src/components/layout-components/dispensasjon/index.js
+++ b/src/components/layout-components/dispensasjon/index.js
@@ -3,7 +3,7 @@ import { instantiateComponent } from "../../../functions/componentHelpers.js";
 
 // Global functions
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
-import { appendChildren, getComponentContainerElement, renderLayoutContainerElement } from "../../../functions/helpers.js";
+import { appendChildren, getComponentContainerElement, hasValue, renderLayoutContainerElement } from "../../../functions/helpers.js";
 
 // Local functions
 import {
@@ -36,6 +36,8 @@ import {
     renderStedfestingVertikalnivaa,
     renderTiltakshaverAdresse,
     renderTiltakshaverTable,
+    renderAnsvarligSoekerTable,
+    renderAnsvarligSoekerAdresse,
     renderTiltakstyperTypeHeader,
     renderTiltakstyperTypeKode,
     renderVarighetHeader
@@ -62,6 +64,8 @@ export default customElements.define(
                 const tiltakstyperTypeKodeElement = renderTiltakstyperTypeKode(component);
                 const tiltakshaverTableElement = renderTiltakshaverTable(component);
                 const tiltakshaverAdresseElement = renderTiltakshaverAdresse(component);
+                const ansvarligSoekerTableElement = renderAnsvarligSoekerTable(component);
+                const ansvarligSoekerAdresseElement = renderAnsvarligSoekerAdresse(component);
                 const dispensasjonHeader2Element = renderDispansasjonHeader(component, "h2");
                 const inngangsbeskrivelseElement = renderInngangsbeskrivelse(component);
                 const dispensasjonBeskrivelseElement = renderDispensasjonBeskrivelse(component);
@@ -105,7 +109,11 @@ export default customElements.define(
                 ]);
 
                 // Soeker
-                appendChildren(layoutContainerElement, [tiltakshaverTableElement, tiltakshaverAdresseElement]);
+                if (hasValue(component?.resourceValues?.data?.ansvarligSoeker)) {
+                    appendChildren(layoutContainerElement, [ansvarligSoekerTableElement, ansvarligSoekerAdresseElement]);
+                } else if (hasValue(component?.resourceValues?.data?.tiltakshaver)) {
+                    appendChildren(layoutContainerElement, [tiltakshaverTableElement, tiltakshaverAdresseElement]);
+                }
 
                 // Dispensasjonsbeskrivelse
                 appendChildren(layoutContainerElement, [dispensasjonHeader2Element, inngangsbeskrivelseElement, dispensasjonBeskrivelseElement]);

--- a/src/components/layout-components/dispensasjon/renderers.js
+++ b/src/components/layout-components/dispensasjon/renderers.js
@@ -254,6 +254,52 @@ export function renderTiltakshaverAdresse(component) {
 }
 
 /**
+ * Renders a custom table part for "Ansvarlig Søker" using provided component data.
+ *
+ * @param {Object} component - The component containing resource values.
+ * @param {Object} component.resourceValues - The resource values object.
+ * @param {Object} component.resourceValues.data - The data object containing "ansvarligSoeker".
+ * @returns {HTMLElement} The custom table part element for "Ansvarlig Søker".
+ */
+export function renderAnsvarligSoekerTable(component) {
+    const data = component?.resourceValues?.data;
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        partType: "ansvarligSoeker",
+        hideIfEmpty: true,
+        resourceValues: {
+            data: data?.ansvarligSoeker
+        }
+    });
+
+    return createCustomElement("custom-table-part", htmlAttributes);
+}
+
+/**
+ * Renders the "Ansvarlig Soeker Adresse" custom field component.
+ *
+ * @param {Object} component - The component object containing resource values and bindings.
+ * @param {Object} component.resourceValues - The resource values for the component.
+ * @param {Object} component.resourceBindings - The resource bindings for the component.
+ * @returns {HTMLElement} The rendered custom field address element wrapped in a container.
+ */
+export function renderAnsvarligSoekerAdresse(component) {
+    const data = component?.resourceValues?.data;
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: true,
+        resourceBindings: {
+            title: component.resourceBindings?.ansvarligSoekerAdresse?.title
+        },
+        resourceValues: {
+            data: data?.ansvarligSoeker?.adresse
+        }
+    });
+
+    return addContainerElement(createCustomElement("custom-field-adresse", htmlAttributes));
+}
+
+/**
  * Renders the "inngangsbeskrivelse" (entrance description) field for a dispensasjon component.
  *
  * This function checks if either the "annenInngangsbeskrivelse" (other entrance description)


### PR DESCRIPTION
Adds the possibility to specify a responsible applicant ("ansvarlig søker") in addition to the property owner ("tiltakshaver") for dispensations.

This includes adding the necessary data structures, rendering components, and logic to handle the responsible applicant's information. It checks if "ansvarligSoeker" is provided, otherwise defaulting to "tiltakshaver".
