### PR TITLE
Hotfix/69 title element for custom summation arealdisponering component not displaying

### DIFF
--- a/src/classes/system-classes/component-classes/CustomSummationArealdisponering.js
+++ b/src/classes/system-classes/component-classes/CustomSummationArealdisponering.js
@@ -40,6 +40,7 @@ export default class CustomSummationArealdisponering extends CustomComponent {
             emptyFieldText: resourceBindings?.arealdisponering?.emptyFieldText || undefined
         };
         this.resourceValues = {
+            title: !props?.hideTitle && getTextResourceFromResourceBinding(resourceBindings?.arealdisponering?.title),
             data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.arealdisponering?.emptyFieldText) : data
         };
     }
@@ -193,6 +194,12 @@ export default class CustomSummationArealdisponering extends CustomComponent {
                 unit: "resource.unit.meterSquared"
             }
         };
+        if (!props?.hideTitle === true || !props?.hideTitle === "true") {
+            resourceBindings.arealdisponering = {
+                ...resourceBindings.arealdisponering,
+                title: props?.resourceBindings?.title || "resource.arealdisponering.title"
+            };
+        }
         if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
             resourceBindings.arealdisponering = {
                 emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"

--- a/src/components/data-components/custom-summation-arealdisponering/README.md
+++ b/src/components/data-components/custom-summation-arealdisponering/README.md
@@ -9,6 +9,7 @@
 | hideIfEmpty                                                 | boolean | Determines whether the element should be hidden when it contains no content.           | false                                                                          |
 | dataModelBindings.data                                      | string  | Reference to an object in the data model containing values for the summation component |                                                                                |
 | resourceBindings.emptyFieldText                             | string  | The resource binding for the text to display when the field is empty.                  | "resource.emptyFieldText.default"                                              |
+| resourceBindings.title                                      | string  | The resource binding key for the title of the component.                               | "resource.rammebetingelser.arealdisponering.title"                             |
 | resourceBindings.tomtearealet.title                         | string  | The resource binding key for the title of the "tomtearealet" section.                  | "resource.rammebetingelser.arealdisponering.tomtearealet.title"                |
 | resourceBindings.bebyggelsen.title                          | string  | The resource binding key for the title of the "bebyggelsen" section.                   | "resource.rammebetingelser.arealdisponering.bebyggelsen.title"                 |
 | resourceBindings.arealBebyggelseEksisterende.title          | string  | The resource binding key for the title of "areal bebyggelse (eksisterende)".           | "resource.rammebetingelser.arealdisponering.arealBebyggelseEksisterende.title" |
@@ -56,7 +57,8 @@
         "data": "arealdisponering"
     },
     "resourceBindings": {
-        "emptyFieldText": "resource.arealdisponering.emptyFieldText"
+        "emptyFieldText": "resource.arealdisponering.emptyFieldText",
+        "title": "resource.rammebetingelser.arealdisponering.title"
     }
 }
 ```

--- a/src/components/data-components/custom-summation-arealdisponering/index.js
+++ b/src/components/data-components/custom-summation-arealdisponering/index.js
@@ -6,7 +6,7 @@ import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js
 import { getComponentContainerElement } from "../../../functions/helpers.js";
 
 // Local functions
-import { renderEmptyFieldText, renderSummationArealdisponering } from "./renderers.js";
+import { renderEmptyFieldText, renderHeaderElement, renderSummationArealdisponering } from "./renderers.js";
 
 export default customElements.define(
     "custom-summation-arealdisponering",
@@ -22,6 +22,9 @@ export default customElements.define(
             } else {
                 const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
                 const summationArealdisponeringElement = renderSummationArealdisponering(component);
+                if (!component?.hideTitle) {
+                    this.appendChild(renderHeaderElement(component, "h2"));
+                }
                 this.appendChild(summationArealdisponeringElement);
                 if (feedbackListElement) {
                     this.appendChild(feedbackListElement);

--- a/src/components/data-components/custom-summation-arealdisponering/renderers.js
+++ b/src/components/data-components/custom-summation-arealdisponering/renderers.js
@@ -5,6 +5,24 @@ import CustomElementHtmlAttributes from "../../../classes/system-classes/CustomE
 import { addContainerElement, createCustomElement } from "../../../functions/helpers.js";
 
 /**
+ * Renders a custom header element for a given component.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {string} [size="h2"] - The size of the header element (e.g., "h1", "h2", etc.).
+ * @returns {HTMLElement} The created custom header element.
+ */
+export function renderHeaderElement(component, size = "h2") {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        size,
+        resourceValues: {
+            title: component?.resourceValues?.title
+        }
+    });
+    return createCustomElement("custom-header-text", htmlAttributes);
+}
+
+/**
  * Renders a custom summation data element using the provided data.
  *
  * @param {Object} data - The data object containing properties for rendering.


### PR DESCRIPTION
Adds title resource binding and header rendering to summation component.

This pull request introduces the ability to display a title for the `custom-summation-arealdisponering` component by adding a `title` resource binding and implementing header rendering logic. The component now dynamically renders a header element if the hideTitle property is not set.

### Changes

- Added `title` resource binding to `CustomSummationArealdisponering` component, allowing configuration of the component's title via resource binding.
- Introduced `renderHeaderElement` function in `renderers.js` to create and render the header element using the `custom-header-text` component.
- Modified `custom-summation-arealdisponering/index.js` to include the header element in the component's rendering if the `hideTitle` prop is not set.
- Updated `README.md` to document the new `resourceBindings.title` property.

### Impact

- The `custom-summation-arealdisponering` component now displays a title based on the configured resource binding, improving its usability and context.
- Added a new dependency on `custom-header-text` component, which is used for rendering the title.
- The component's visual presentation is modified by the inclusion of a header.

Closes: #69 