### PR TITLE
Hotfix/74 empty custom header text renders when title is missing or hidetitle is true

### DIFF
--- a/src/components/base-components/custom-summation/index.js
+++ b/src/components/base-components/custom-summation/index.js
@@ -1,5 +1,5 @@
 // Global functions
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { getComponentContainerElement, hasValue } from "../../../functions/helpers.js";
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
 
 // Local functions
@@ -18,11 +18,10 @@ export default customElements.define(
             if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
                 componentContainerElement.style.display = "none";
             } else {
-                const headerElement = renderHeaderElement(component?.resourceValues?.title, component?.size);
                 const summationElement = renderSummationElement(component?.resourceValues?.data);
                 this.innerHTML = "";
-                if (headerElement) {
-                    this.appendChild(headerElement);
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
                 }
                 this.appendChild(summationElement);
             }

--- a/src/components/base-components/custom-table/index.js
+++ b/src/components/base-components/custom-table/index.js
@@ -2,7 +2,7 @@
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
 
 // Global functions
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { getComponentContainerElement, hasValue } from "../../../functions/helpers.js";
 
 // Local functions
 import { renderHeaderElement, renderTableElement } from "./renderers.js";
@@ -19,11 +19,10 @@ export default customElements.define(
             if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
                 componentContainerElement.style.display = "none";
             } else {
-                const headerElement = renderHeaderElement(component?.resourceValues?.title, component?.size);
                 const tableElement = renderTableElement(component);
                 this.innerHTML = "";
-                if (headerElement) {
-                    this.appendChild(headerElement);
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
                 }
                 this.appendChild(tableElement);
             }

--- a/src/components/data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js
+++ b/src/components/data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js
@@ -1,7 +1,7 @@
 // Global functions
 import { instantiateComponent } from "../../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
+import { getComponentContainerElement, hasValue } from "../../../../functions/helpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHeaderElement, renderKommentarElement, renderTemaElement, renderVedleggslisteElement } from "./renderers.js";
@@ -19,7 +19,9 @@ export default customElements.define(
                 this.appendChild(emptyFieldTextElement);
             } else {
                 const containerElement = document.createElement("div");
-                containerElement.appendChild(renderHeaderElement(component, "h3"));
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    containerElement.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
                 containerElement.appendChild(renderTemaElement(component));
                 containerElement.appendChild(renderKommentarElement(component));
                 containerElement.appendChild(renderVedleggslisteElement(component));

--- a/src/components/data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js
+++ b/src/components/data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js
@@ -25,9 +25,9 @@ export default customElements.define(
                 containerElement.appendChild(renderVedleggslisteElement(component));
                 this.appendChild(containerElement);
 
-                const feebackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-                if (feebackListElement) {
-                    this.appendChild(feebackListElement);
+                const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+                if (feedbackListElement) {
+                    this.appendChild(feedbackListElement);
                 }
             }
         }

--- a/src/components/data-components/custom-grouplist-ettersending/index.js
+++ b/src/components/data-components/custom-grouplist-ettersending/index.js
@@ -1,5 +1,5 @@
 // Global functions
-import { createCustomElement, getComponentContainerElement } from "../../../functions/helpers.js";
+import { createCustomElement, getComponentContainerElement, hasValue } from "../../../functions/helpers.js";
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
 
@@ -18,7 +18,9 @@ export default customElements.define(
                 const emptyFieldTextElement = renderEmptyFieldText(component);
                 this.appendChild(emptyFieldTextElement);
             } else {
-                this.appendChild(renderHeaderElement(component, "h2"));
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
                 for (const ettersending of component?.resourceValues?.data ?? []) {
                     const ettersendingElement = renderEttersendingGroup(ettersending, component);
                     this.appendChild(ettersendingElement);

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/index.js
@@ -1,7 +1,7 @@
 // Global functions
 import { instantiateComponent } from "../../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
+import { getComponentContainerElement, hasValue } from "../../../../functions/helpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHeaderElement, renderSjekklistepunk } from "./renderers.js";
@@ -19,7 +19,9 @@ export default customElements.define(
                 this.appendChild(emptyFieldTextElement);
             } else {
                 const containerElement = document.createElement("div");
-                containerElement.appendChild(renderHeaderElement(component, "h3"));
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    containerElement.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
                 containerElement.appendChild(renderSjekklistepunk(component));
                 this.appendChild(containerElement);
 

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/index.js
@@ -1,5 +1,5 @@
 // Global functions
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { getComponentContainerElement, hasValue } from "../../../functions/helpers.js";
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
 
@@ -18,7 +18,9 @@ export default customElements.define(
                 const emptyFieldTextElement = renderEmptyFieldText(component);
                 this.appendChild(emptyFieldTextElement);
             } else {
-                this.appendChild(renderHeaderElement(component, "h2"));
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
                 for (const sjekklistekrav of component?.resourceValues?.data ?? []) {
                     const sjekklistekravElement = renderSjekklistekravGroup(sjekklistekrav, component);
                     this.appendChild(sjekklistekravElement);

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js
@@ -1,5 +1,5 @@
 // Global functions
-import { getComponentContainerElement } from "../../../../../../functions/helpers.js";
+import { getComponentContainerElement, hasValue } from "../../../../../../functions/helpers.js";
 import { instantiateComponent } from "../../../../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../../../../functions/feedbackHelpers.js";
 
@@ -23,7 +23,9 @@ export default customElements.define(
                 componentContainerElement.style.display = "none";
             } else {
                 const containerElement = document.createElement("div");
-                containerElement.appendChild(renderHeaderElement(component, "h3"));
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    containerElement.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
                 containerElement.appendChild(renderBeskrivelseElement(component));
                 containerElement.appendChild(renderStatusElement(component));
                 containerElement.appendChild(renderTemaElement(component));

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js
@@ -31,9 +31,9 @@ export default customElements.define(
                 containerElement.appendChild(renderVedleggslisteElement(component));
                 this.appendChild(containerElement);
 
-                const feebackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-                if (feebackListElement) {
-                    this.appendChild(feebackListElement);
+                const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+                if (feedbackListElement) {
+                    this.appendChild(feedbackListElement);
                 }
             }
         }

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/index.js
@@ -1,5 +1,5 @@
 // Global functions
-import { createCustomElement, getComponentContainerElement } from "../../../../../functions/helpers.js";
+import { createCustomElement, getComponentContainerElement, hasValue } from "../../../../../functions/helpers.js";
 import { instantiateComponent } from "../../../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../../../functions/feedbackHelpers.js";
 
@@ -18,7 +18,9 @@ export default customElements.define(
                 const emptyFieldTextElement = renderEmptyFieldText(component);
                 this.appendChild(emptyFieldTextElement);
             } else {
-                this.appendChild(renderHeaderElement(component, "h2"));
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
                 for (const utfallSvar of component?.resourceValues?.data ?? []) {
                     const utfallSvarElement = renderUtfallSvarGroup(utfallSvar, component);
                     this.appendChild(utfallSvarElement);

--- a/src/components/data-components/custom-summation-arealdisponering/index.js
+++ b/src/components/data-components/custom-summation-arealdisponering/index.js
@@ -22,7 +22,7 @@ export default customElements.define(
             } else {
                 const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
                 const summationArealdisponeringElement = renderSummationArealdisponering(component);
-                if (!component?.hideTitle) {
+                if (component?.resourceValues?.title && component?.hideTitle !== true) {
                     this.appendChild(renderHeaderElement(component, "h2"));
                 }
                 this.appendChild(summationArealdisponeringElement);

--- a/src/components/data-components/custom-summation-data/renderers.js
+++ b/src/components/data-components/custom-summation-data/renderers.js
@@ -14,7 +14,8 @@ import { createCustomElement } from "../../../functions/helpers.js";
 export function renderSummationData(component) {
     const htmlAttributes = new CustomElementHtmlAttributes({
         size: "h3",
-        hideIfEmpty: true,
+        hideIfEmpty: component?.hideIfEmpty,
+        hideTitle: component?.hideTitle,
         isChildComponent: true,
         resourceValues: component?.resourceValues
     });


### PR DESCRIPTION
Conditionally render component titles based on `hasValue` and `hideTitle`.

The pull request modify several components to conditionally render their titles. The `hasValue` helper function is used to check if a title exists, and the `hideTitle` property is checked to determine if the title should be hidden. The changes aim to provide more control over title visibility for individual components.

### Changes

- Introduced `hasValue` check for titles before rendering in multiple components.
- Added `hideTitle` property check to prevent rendering of titles.
- Replaced direct `appendChild` calls for header elements with conditional logic based on title presence and `hideTitle` flag.
- Modified base components:
  - `custom-summation`
  - `custom-table`
- Modified data components:
  - `custom-group-ettersending`
  - `custom-grouplist-ettersending`
  - `custom-group-sjekklistekrav`
  - `custom-grouplist-sjekklistekrav`
  - `custom-group-utfall-svar`
  - `custom-grouplist-utfall-svar`
  - `custom-summation-arealdisponering`
  - `custom-summation-data`

### Impact

- Component titles are now conditionally rendered, improving flexibility and control over UI elements.
- Components now respect the `hideTitle` property, allowing developers to easily hide titles when needed.
- The `hasValue` helper function is now a dependency in the modified components, requiring it to be available in the specified file path.
- There is no indication of breaking changes or performance implications based on the diff.

Closes: #74 