### PR TITLE
Feature/add label support planlagte loefteinnretninger

### DIFF
--- a/src/classes/system-classes/component-classes/CustomListPlanlagteLoefteinnretninger.js
+++ b/src/classes/system-classes/component-classes/CustomListPlanlagteLoefteinnretninger.js
@@ -33,11 +33,11 @@ export default class CustomListPlanlagteLoefteinnretninger extends CustomCompone
         this.validationMessages = validationMessages;
         this.hasValidationMessages = hasValidationMessages(validationMessages);
         this.resourceBindings = {
-            emptyFieldText: resourceBindings?.arealdisponering?.emptyFieldText || undefined
+            emptyFieldText: resourceBindings?.loefteinnretninger?.emptyFieldText || undefined
         };
         this.resourceValues = {
-            title: !props?.hideTitle && getTextResourceFromResourceBinding(resourceBindings?.arealdisponering?.title),
-            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.arealdisponering?.emptyFieldText) : data
+            title: !props?.hideTitle && getTextResourceFromResourceBinding(resourceBindings?.loefteinnretninger?.title),
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.loefteinnretninger?.emptyFieldText) : data
         };
     }
 

--- a/src/classes/system-classes/component-classes/CustomListPlanlagteLoefteinnretninger.js
+++ b/src/classes/system-classes/component-classes/CustomListPlanlagteLoefteinnretninger.js
@@ -115,8 +115,14 @@ export default class CustomListPlanlagteLoefteinnretninger extends CustomCompone
                     props?.resourceBindings?.planleggesTrappeheis?.title || `resource.rammebetingelser.loefteinnretninger.planleggesTrappeheis.title`
             }
         };
+        if (!props?.hideTitle === true || !props?.hideTitle === "true") {
+            resourceBindings.loefteinnretninger = {
+                title: props?.resourceBindings?.title || "resource.loefteinnretninger.title"
+            };
+        }
         if (!props?.hideIfEmpty === true || !props?.hideIfEmpty === "true") {
             resourceBindings.loefteinnretninger = {
+                ...resourceBindings.loefteinnretninger,
                 emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"
             };
         }


### PR DESCRIPTION
Fix: Updates resource binding for lift equipment component.

The code changes update the resource bindings for the `CustomListPlanlagteLoefteinnretninger` component to use `loefteinnretninger` instead of `arealdisponering`. This ensures the component correctly retrieves its title and empty field text from the resource bundle.

### Changes

- Updated `emptyFieldText` resource binding from `resourceBindings?.arealdisponering?.emptyFieldText` to `resourceBindings?.loefteinnretninger?.emptyFieldText`.
- Updated `title` resource value binding from `resourceBindings?.arealdisponering?.title` to `resourceBindings?.loefteinnretninger?.title`.
- Updated `data` resource value binding when `isEmpty` is `true` from `resourceBindings?.arealdisponering?.emptyFieldText` to `resourceBindings?.loefteinnretninger?.emptyFieldText`.
- Modified component: `src/classes/system-classes/component-classes/CustomListPlanlagteLoefteinnretninger.js`

### Impact

- The component will now display the correct title and empty field text based on the `loefteinnretninger` resource binding, fixing the previous incorrect binding.
- This change affects the visual presentation of the `CustomListPlanlagteLoefteinnretninger` component.
- No breaking changes or performance implications are apparent.
