### PR TITLE
Allows size configuration for table components

### DIFF
--- a/src/components/data-components/custom-table-eiendom/renderers.js
+++ b/src/components/data-components/custom-table-eiendom/renderers.js
@@ -14,6 +14,7 @@ import { createCustomElement } from "../../../functions/helpers.js";
  * @param {Object} component - The component configuration object containing resource bindings and values.
  * @param {Object} [component.resourceBindings] - Resource bindings for column titles and empty field text.
  * @param {Object} [component.resourceValues] - Resource values for the table.
+ * @param {string} [component.size] - Size attribute for the custom table element.
  * @returns {HTMLElement} The rendered custom table element.
  */
 export function renderEiendomTable(component) {
@@ -81,7 +82,7 @@ export function renderEiendomTable(component) {
         }
     ];
     const htmlAttributes = new CustomElementHtmlAttributes({
-        size: "h3",
+        size: component?.size,
         hideIfEmpty: true,
         isChildComponent: true,
         resourceValues: component?.resourceValues,

--- a/src/components/data-components/custom-table-part/renderers.js
+++ b/src/components/data-components/custom-table-part/renderers.js
@@ -21,6 +21,7 @@ import { createCustomElement } from "../../../functions/helpers.js";
  * @param {Object} [component.resourceBindings.part] - Resource bindings for the table part title.
  * @param {string} [component.resourceBindings.part.title] - Title for the table part.
  * @param {Object} [component.resourceValues] - Resource values for the table.
+ * @param {string} [component.size] - Size attribute for the custom table element.
  * @returns {HTMLElement} The rendered custom table element.
  */
 export function renderPartTable(component) {
@@ -49,7 +50,7 @@ export function renderPartTable(component) {
         }
     ];
     const htmlAttributes = new CustomElementHtmlAttributes({
-        size: "h3",
+        size: component?.size,
         hideIfEmpty: true,
         isChildComponent: true,
         resourceValues: component?.resourceValues,


### PR DESCRIPTION
Enables the configuration of the "size" attribute for the custom table components (Eiendom and Part) by reading the size property from the component configuration.

This fixes an issue where the size property was not being correctly applied to the table components.

Fixes #82