### PR TITLE
Adjust header sizes for dispensasjon component

### DIFF
--- a/src/components/layout-components/dispensasjon/renderers.js
+++ b/src/components/layout-components/dispensasjon/renderers.js
@@ -144,6 +144,7 @@ export function renderEiendomTable(component) {
     const htmlAttributes = new CustomElementHtmlAttributes({
         isChildComponent: true,
         hideIfEmpty: true,
+        size: "h3",
         resourceBindings: {
             title: component.resourceBindings?.eiendomByggested?.title
         },
@@ -218,6 +219,7 @@ export function renderTiltakshaverTable(component) {
         isChildComponent: true,
         partType: "tiltakshaver",
         hideIfEmpty: true,
+        size: "h2",
         resourceValues: {
             data: data?.tiltakshaver
         }
@@ -267,6 +269,7 @@ export function renderAnsvarligSoekerTable(component) {
         isChildComponent: true,
         partType: "ansvarligSoeker",
         hideIfEmpty: true,
+        size: "h2",
         resourceValues: {
             data: data?.ansvarligSoeker
         }


### PR DESCRIPTION
Modifies the header sizes within the dispensasjon component for improved visual hierarchy and readability.

Sets specific header sizes for `eiendom`, ´tiltakshaver` and `ansvarligSoeker` tables.