### PR TITLE
Adds meter squared formatting option

### DIFF
--- a/src/components/data-components/custom-field-data/README.md
+++ b/src/components/data-components/custom-field-data/README.md
@@ -1,19 +1,19 @@
 # Data (field)
 
-| Property                        | Type              | Description                                                                         | Default value |
-| :------------------------------ | :---------------- | :---------------------------------------------------------------------------------- | :------------ |
-| id                              | string            | The unique identifier for the custom field.                                         |               |
-| type                            | string            | The type of the custom field, which is "Custom".                                    |               |
-| tagName                         | string            | The tag name for the custom field, which is "custom-field-data".                    |               |
-| hideTitle                       | boolean           | A flag indicating whether the title should be hidden.                               | false         |
-| hideIfEmpty                     | boolean           | Determines whether the element should be hidden when it contains no content.        | false         |
-| format                          | string            | The format of the data value, e.g., "date", "time", "dateTime", "AR"                |               |
-| inline                          | boolean           | A flag indicating whether the title and value should be displayed on the same line. | false         |
-| enableLinks                     | boolean           | A flag indicating whether links should be generated from URLs in content.           | false         |
-| dataModelBindings.simpleBinding | string            | Reference to a string, number or boolean value in the data model.                   |               |
-| resourceBindings.title          | string            | The title text resource binding.                                                    |               |
-| resourceBindings.emptyFieldText | string            | The resource binding for the text to display when the field is empty.               |               |
-| styleOverride                   | HTMLElement.style | The style override for the custom field.                                            |               |
+| Property                        | Type              | Description                                                                          | Default value |
+| :------------------------------ | :---------------- | :----------------------------------------------------------------------------------- | :------------ |
+| id                              | string            | The unique identifier for the custom field.                                          |               |
+| type                            | string            | The type of the custom field, which is "Custom".                                     |               |
+| tagName                         | string            | The tag name for the custom field, which is "custom-field-data".                     |               |
+| hideTitle                       | boolean           | A flag indicating whether the title should be hidden.                                | false         |
+| hideIfEmpty                     | boolean           | Determines whether the element should be hidden when it contains no content.         | false         |
+| format                          | string            | The format of the data value, e.g., "date", "time", "dateTime", "AR", "meterSquared" |               |
+| inline                          | boolean           | A flag indicating whether the title and value should be displayed on the same line.  | false         |
+| enableLinks                     | boolean           | A flag indicating whether links should be generated from URLs in content.            | false         |
+| dataModelBindings.simpleBinding | string            | Reference to a string, number or boolean value in the data model.                    |               |
+| resourceBindings.title          | string            | The title text resource binding.                                                     |               |
+| resourceBindings.emptyFieldText | string            | The resource binding for the text to display when the field is empty.                |               |
+| styleOverride                   | HTMLElement.style | The style override for the custom field.                                             |               |
 
 ## Example
 

--- a/src/functions/dataFormatHelpers.js
+++ b/src/functions/dataFormatHelpers.js
@@ -153,10 +153,20 @@ export function formatAR(data) {
 }
 
 /**
+ * Formats a numeric value as square meters (m²).
+ *
+ * @param {number|string} value - The value to format.
+ * @returns {string} The formatted string with square meters unit.
+ */
+export function formatMeterSquared(value) {
+    return `${value} m²`;
+}
+
+/**
  * Formats a given string based on the specified format and language.
  *
  * @param {string} string - The string to be formatted.
- * @param {string} format - The format type ("dateTime", "date", "time", "AR").
+ * @param {string} format - The format type ("dateTime", "date", "time", "AR", "meterSquared").
  * @param {string} [language="default"] - The language to use for formatting (default is "default").
  * @returns {string} - The formatted string.
  */
@@ -170,6 +180,8 @@ export function formatString(string, format, language = "default") {
             return formatTime(string, language);
         case "AR":
             return formatAR(string);
+        case "meterSquared":
+            return formatMeterSquared(string);
         default:
             return string;
     }

--- a/src/functions/dataFormatHelpers.test.js
+++ b/src/functions/dataFormatHelpers.test.js
@@ -167,6 +167,10 @@ describe("formatString", () => {
     it("formats AR", () => {
         expect(formatString("abc-def", "AR")).toBe("def");
     });
+    it("formats meterSquared correctly", () => {
+        expect(formatString(123, "meterSquared")).toBe("123 m²");
+        expect(formatString("456", "meterSquared")).toBe("456 m²");
+    });
     it("returns input for unknown format", () => {
         expect(formatString("abc", "unknown")).toBe("abc");
     });


### PR DESCRIPTION
Adds a new formatting option for displaying numeric values as square meters (m²).

This allows users to easily format area measurements with the correct unit, improving the readability and clarity of displayed data.