### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Arkitektum/altinn-studio-custom-components/security/code-scanning/9](https://github.com/Arkitektum/altinn-studio-custom-components/security/code-scanning/9)

To fix the issue, add a `permissions` block to the workflow or specifically to the `build` job. The recommended practice is to provide the minimal necessary privileges—in this case, read-only access to repository contents—by setting `permissions: contents: read`. This can be set at the workflow root level (before `jobs:`) to cover all jobs not otherwise configured, or within a job definition if specific jobs have different requirements. For the provided snippet, the most straightforward and safest change is to place the `permissions` block at the root level, before the `jobs:` key on line 9, giving all jobs the minimum required read-only access.

No additional imports, methods, or configuration files are needed—just editing the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
