### PR TITLE
Fix resource bindings for GjenpartNabovarsel and neighbor property components

### DIFF
--- a/src/classes/system-classes/component-classes/CustomGjenpartNabovarsel.js
+++ b/src/classes/system-classes/component-classes/CustomGjenpartNabovarsel.js
@@ -130,11 +130,6 @@ export default class CustomGjenpartNabovarsel extends CustomComponent {
                 title: props?.resourceBindings?.bygningsnummer?.title || "resource.eiendom.bygningsnummer.title",
                 emptyFieldText: props?.resourceBindings?.bygningsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
-            eiendomMatrikkelinformasjon: {
-                title:
-                    props?.resourceBindings?.eiendomMatrikkelinformasjon?.title ||
-                    "resource.naboGjenboer.eiendommer.eiendom.matrikkelinformasjon.title"
-            },
             detErVarsletOm: {
                 title: props?.resourceBindings?.detErVarsletOm?.title || "resource.detErVarsletOm.title"
             },
@@ -185,6 +180,15 @@ export default class CustomGjenpartNabovarsel extends CustomComponent {
             },
             tiltakshaver: {
                 title: props?.resourceBindings?.tiltakshaver?.title || "resource.tiltakshaver.title"
+            },
+            eiendomMatrikkelinformasjon: {
+                title:
+                    props?.resourceBindings?.eiendomMatrikkelinformasjon?.title ||
+                    "resource.naboGjenboer.eiendommer.eiendom.matrikkelinformasjon.title"
+            },
+            eiendomMatrikkelinformasjonAdresse: {
+                title: props?.resourceBindings?.eiendomMatrikkelinformasjonAdresse?.title || "resource.eiendom.adresse.title",
+                emptyFieldText: props?.resourceBindings?.eiendomMatrikkelinformasjonAdresse?.emptyFieldText || "resource.emptyFieldText.address"
             },
             eiendomMatrikkelinformasjonEiendomsidentifikasjonGaardsnummer: {
                 title:

--- a/src/classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.js
@@ -149,7 +149,7 @@ export default class CustomGroupNaboGjenboerEiendom extends CustomComponent {
                 emptyFieldText: props?.resourceBindings?.responsNabovarselSendt?.emptyFieldText || "resource.emptyFieldText.default"
             },
             responsErMerknadEllerSamtykkeMottatt: {
-                title: props?.resourceBindings?.responsErMerknadEllerSamtykkeMottatt?.title || "resource.respons.erMerknadEllerSamtykkeMottatt.title",
+                title: props?.resourceBindings?.responsErMerknadEllerSamtykkeMottatt?.title || "resource.status.title",
                 falseText:
                     props?.resourceBindings?.responsErMerknadEllerSamtykkeMottatt?.falseText ||
                     "resource.respons.erMerknadEllerSamtykkeMottatt.falseText"

--- a/src/classes/system-classes/component-classes/CustomGrouplistNaboGjenboerEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistNaboGjenboerEiendom.js
@@ -191,7 +191,7 @@ export default class CustomGrouplistNaboGjenboerEiendom extends CustomComponent 
                 emptyFieldText: props?.resourceBindings?.responsNabovarselSendt?.emptyFieldText || "resource.emptyFieldText.default"
             },
             responsErMerknadEllerSamtykkeMottatt: {
-                title: props?.resourceBindings?.responsErMerknadEllerSamtykkeMottatt?.title || "resource.respons.erMerknadEllerSamtykkeMottatt.title",
+                title: props?.resourceBindings?.responsErMerknadEllerSamtykkeMottatt?.title || "resource.status.title",
                 falseText:
                     props?.resourceBindings?.responsErMerknadEllerSamtykkeMottatt?.falseText ||
                     "resource.respons.erMerknadEllerSamtykkeMottatt.falseText"


### PR DESCRIPTION
Adds the missing address resource binding for property information and updates response status titles to use generic resource keys.