### PR TITLE
Feature/add custom group rammebetingelser krav til byggegrunn component

### DIFF
--- a/src/classes/data-classes/KravTilByggegrunn.js
+++ b/src/classes/data-classes/KravTilByggegrunn.js
@@ -1,0 +1,17 @@
+// Classes
+import MuligeOmraadeRisikoer from "./MuligeOmraadeRisikoer.js";
+
+/**
+ * Represents the requirements for building ground, including possible area risks and environmental conditions.
+ *
+ * @class KravTilByggegrunn
+ * @param {Object} props - The properties to initialize the KravTilByggegrunn instance.
+ * @param {Object} [props.muligeOmraadeRisikoer] - The data for possible area risks, used to create a MuligeOmraadeRisikoer instance.
+ * @param {string} [props.miljoeforhold] - Environmental conditions related to the building ground.
+ */
+export default class KravTilByggegrunn {
+    constructor(props) {
+        this.muligeOmraadeRisikoer = props?.muligeOmraadeRisikoer && new MuligeOmraadeRisikoer(props.muligeOmraadeRisikoer);
+        this.miljoeforhold = props?.miljoeforhold;
+    }
+}

--- a/src/classes/data-classes/KravTilByggegrunn.js
+++ b/src/classes/data-classes/KravTilByggegrunn.js
@@ -7,11 +7,11 @@ import MuligeOmraadeRisikoer from "./MuligeOmraadeRisikoer.js";
  * @class KravTilByggegrunn
  * @param {Object} props - The properties to initialize the KravTilByggegrunn instance.
  * @param {Object} [props.muligeOmraadeRisikoer] - The data for possible area risks, used to create a MuligeOmraadeRisikoer instance.
- * @param {string} [props.miljoeforhold] - Environmental conditions related to the building ground.
+ * @param {boolean} [props.harMiljoeforhold] - Indicates if there are environmental conditions related to the building ground.
  */
 export default class KravTilByggegrunn {
     constructor(props) {
         this.muligeOmraadeRisikoer = props?.muligeOmraadeRisikoer && new MuligeOmraadeRisikoer(props.muligeOmraadeRisikoer);
-        this.miljoeforhold = props?.miljoeforhold;
+        this.harMiljoeforhold = props?.harMiljoeforhold;
     }
 }

--- a/src/classes/data-classes/KravTilByggegrunn.test.js
+++ b/src/classes/data-classes/KravTilByggegrunn.test.js
@@ -1,0 +1,32 @@
+import KravTilByggegrunn from "./KravTilByggegrunn";
+import MuligeOmraadeRisikoer from "./MuligeOmraadeRisikoer";
+
+describe("KravTilByggegrunn", () => {
+    it("should initialize muligeOmraadeRisikoer as instance if provided", () => {
+        const data = { omraadeRisiko: [] };
+        const instance = new KravTilByggegrunn({ muligeOmraadeRisikoer: data });
+        expect(instance.muligeOmraadeRisikoer).toBeInstanceOf(MuligeOmraadeRisikoer);
+    });
+
+    it("should set muligeOmraadeRisikoer as undefined if not provided", () => {
+        const instance = new KravTilByggegrunn({});
+        expect(instance.muligeOmraadeRisikoer).toBeUndefined();
+    });
+
+    it("should set harMiljoeforhold if provided", () => {
+        const instance = new KravTilByggegrunn({ harMiljoeforhold: true });
+        expect(instance.harMiljoeforhold).toBe(true);
+    });
+
+    it("should set harMiljoeforhold as undefined if not provided", () => {
+        const instance = new KravTilByggegrunn({});
+        expect(instance.harMiljoeforhold).toBeUndefined();
+    });
+
+    it("should handle both properties together", () => {
+        const data = { omraadeRisiko: [] };
+        const instance = new KravTilByggegrunn({ muligeOmraadeRisikoer: data, harMiljoeforhold: false });
+        expect(instance.muligeOmraadeRisikoer).toBeInstanceOf(MuligeOmraadeRisikoer);
+        expect(instance.harMiljoeforhold).toBe(false);
+    });
+});

--- a/src/classes/data-classes/MuligeOmraadeRisikoer.js
+++ b/src/classes/data-classes/MuligeOmraadeRisikoer.js
@@ -1,0 +1,15 @@
+// Classes
+import Omraaderisiko from "./Omraaderisiko.js";
+
+/**
+ * Represents possible area risks associated with building ground requirements.
+ *
+ * @class MuligeOmraadeRisikoer
+ * @param {Object} props - The properties to initialize the MuligeOmraadeRisikoer instance.
+ * @param {Object} [props.omraadeRisiko] - The area risk data used to create an Omraaderisiko instance.
+ */
+export default class MuligeOmraadeRisikoer {
+    constructor(props) {
+        this.omraadeRisiko = props?.omraadeRisiko && new Omraaderisiko(props.omraadeRisiko);
+    }
+}

--- a/src/classes/data-classes/MuligeOmraadeRisikoer.js
+++ b/src/classes/data-classes/MuligeOmraadeRisikoer.js
@@ -6,10 +6,11 @@ import Omraaderisiko from "./Omraaderisiko.js";
  *
  * @class MuligeOmraadeRisikoer
  * @param {Object} props - The properties to initialize the MuligeOmraadeRisikoer instance.
- * @param {Object} [props.omraadeRisiko] - The area risk data used to create an Omraaderisiko instance.
+ * @param {Array<Object>} [props.omraadeRisiko] - An array of area risk objects to be transformed into Omraaderisiko instances.
  */
 export default class MuligeOmraadeRisikoer {
     constructor(props) {
-        this.omraadeRisiko = props?.omraadeRisiko && new Omraaderisiko(props.omraadeRisiko);
+        this.omraadeRisiko =
+            props?.omraadeRisiko?.length && Array.isArray(props.omraadeRisiko) ? props.omraadeRisiko.map((item) => new Omraaderisiko(item)) : null;
     }
 }

--- a/src/classes/data-classes/MuligeOmraadeRisikoer.test.js
+++ b/src/classes/data-classes/MuligeOmraadeRisikoer.test.js
@@ -1,0 +1,34 @@
+import MuligeOmraadeRisikoer from "./MuligeOmraadeRisikoer";
+import Omraaderisiko from "./Omraaderisiko";
+
+describe("MuligeOmraadeRisikoer", () => {
+    it("should initialize with null if no omraadeRisiko is provided", () => {
+        const instance = new MuligeOmraadeRisikoer({});
+        expect(instance.omraadeRisiko).toBeNull();
+    });
+
+    it("should initialize with null if omraadeRisiko is not an array", () => {
+        const instance = new MuligeOmraadeRisikoer({ omraadeRisiko: "not-an-array" });
+        expect(instance.omraadeRisiko).toBeNull();
+    });
+
+    it("should initialize with Omraaderisiko instances if omraadeRisiko is an array", () => {
+        const data = [
+            { risikotype: { kodeverdi: "A", kodebeskrivelse: "Alpha" }, sikkerhetsklasse: { kodeverdi: "1", kodebeskrivelse: "Low" } },
+            { risikotype: { kodeverdi: "B", kodebeskrivelse: "Beta" }, sikkerhetsklasse: { kodeverdi: "2", kodebeskrivelse: "Medium" } }
+        ];
+        const instance = new MuligeOmraadeRisikoer({ omraadeRisiko: data });
+        expect(Array.isArray(instance.omraadeRisiko)).toBe(true);
+        expect(instance.omraadeRisiko).toHaveLength(2);
+        instance.omraadeRisiko.forEach((item, idx) => {
+            expect(item).toBeInstanceOf(Omraaderisiko);
+            expect(item.risikotype.kodeverdi).toBe(data[idx].risikotype.kodeverdi);
+            expect(item.sikkerhetsklasse.kodebeskrivelse).toBe(data[idx].sikkerhetsklasse.kodebeskrivelse);
+        });
+    });
+
+    it("should initialize with null if omraadeRisiko is an empty array", () => {
+        const instance = new MuligeOmraadeRisikoer({ omraadeRisiko: [] });
+        expect(instance.omraadeRisiko).toBeNull();
+    });
+});

--- a/src/classes/system-classes/component-classes/CustomGroupRammebetingelserKravTilByggegrunn.js
+++ b/src/classes/system-classes/component-classes/CustomGroupRammebetingelserKravTilByggegrunn.js
@@ -1,0 +1,138 @@
+// Dependencies
+import { getTextResourceFromResourceBinding, hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Classes
+import CustomComponent from "../CustomComponent.js";
+import KravTilByggegrunn from "../../data-classes/KravTilByggegrunn.js";
+
+// Global functions
+import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
+import { getComponentDataValue } from "../../../functions/helpers.js";
+
+/**
+ * CustomGroupRammebetingelserKravTilByggegrunn is a custom component class for handling "krav til byggegrunn" group data and resource bindings.
+ *
+ * @extends CustomComponent
+ *
+ * @class
+ * @param {Object} props - The properties for the component, including form data and resource bindings.
+ *
+ * @property {boolean} isEmpty - Indicates if the component data is empty.
+ * @property {boolean} hasValidationMessages - Indicates if there are validation messages.
+ * @property {Object} validationMessages - Validation messages for the component.
+ * @property {Object} resourceBindings - Text resource bindings for the component.
+ * @property {Object} resourceValues - Resource values for rendering, including title and data or empty field text.
+ */
+export default class CustomGroupRammebetingelserKravTilByggegrunn extends CustomComponent {
+    constructor(props) {
+        super(props);
+        const data = this.getValueFromFormData(props);
+        const resourceBindings = this.getResourceBindings(props);
+        const isEmpty = !this.hasContent(data);
+        const validationMessages = this.getValidationMessages(resourceBindings);
+
+        this.isEmpty = isEmpty;
+        this.validationMessages = validationMessages;
+        this.hasValidationMessages = hasValidationMessages(validationMessages);
+        this.resourceBindings = resourceBindings || {};
+        this.resourceValues = {
+            title: hasValue(props?.resourceValues?.title)
+                ? props?.resourceValues?.title
+                : getTextResourceFromResourceBinding(resourceBindings?.rammebetingelserKravTilByggegrunn?.title),
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.rammebetingelserKravTilByggegrunn?.emptyFieldText) : data
+        };
+    }
+
+    /**
+     * Checks if the provided data has a value.
+     *
+     * @param {*} data - The data to check for content.
+     * @returns {boolean} Returns true if the data has a value, otherwise false.
+     */
+    hasContent(data) {
+        return hasValue(data);
+    }
+
+    /**
+     * Retrieves validation messages based on provided resource bindings.
+     *
+     * @param {Object} resourceBindings - The resource bindings to check for missing text resources.
+     * @returns {Array|string|boolean} - The result of checking for missing text resources, which may be an array of messages, a string, or a boolean depending on implementation.
+     */
+    getValidationMessages(resourceBindings) {
+        return hasMissingTextResources(resourceBindings);
+    }
+
+    /**
+     * Retrieves the value from the form data and initializes a KravTilByggegrunn instance.
+     *
+     * @param {*} props - The properties object containing form data.
+     * @returns {KravTilByggegrunn} An instance of KravTilByggegrunn initialized with the form data.
+     */
+    getValueFromFormData(props) {
+        const data = getComponentDataValue(props);
+        const kravTilByggegrunn = new KravTilByggegrunn(data);
+        return kravTilByggegrunn;
+    }
+
+    /**
+     * Generates an object containing resource binding configurations for various components,
+     * providing default resource keys if specific bindings are not supplied via props.
+     *
+     * @param {Object} props - The properties object containing optional resource bindings and flags.
+     * @param {Object} [props.resourceBindings] - Optional resource binding overrides for each component.
+     * @param {boolean|string} [props.hideTitle] - If true or "true", omits the title for rammebetingelserTilknytninger.
+     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", omits the emptyFieldText for rammebetingelserTilknytninger.
+     * @returns {Object} An object mapping component keys to their resource binding configurations.
+     */
+    getResourceBindings(props) {
+        const resourceBindings = {
+            risikotype: {
+                title:
+                    props?.resourceBindings?.risikotype?.title || "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.risikotype.title",
+                emptyFieldText: props?.resourceBindings?.risikotype?.emptyFieldText || "resource.emptyFieldText.default"
+            },
+            sikkerhetsklasse: {
+                title:
+                    props?.resourceBindings?.sikkerhetsklasse?.title ||
+                    "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.sikkerhetsklasse.title",
+                emptyFieldText: props?.resourceBindings?.sikkerhetsklasse?.emptyFieldText || "resource.emptyFieldText.default"
+            },
+            omraaderisiko: {
+                title: props?.resourceBindings?.omraaderisiko?.title || "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.title"
+            },
+            harMiljoeforhold: {
+                title: props?.resourceBindings?.harMiljoeforhold?.title || "resource.rammebetingelser.kravTilByggegrunn.harMiljoeforhold.title",
+                trueText: props?.resourceBindings?.harMiljoeforhold?.trueText || "resource.trueText.default",
+                falseText: props?.resourceBindings?.harMiljoeforhold?.falseText || "resource.falseText.default"
+            }
+        };
+        if (props?.hideTitle !== true && props?.hideTitle !== "true") {
+            resourceBindings.rammebetingelserKravTilByggegrunn = {
+                title: props?.resourceBindings?.title || "resource.kravTilByggegrunn.title"
+            };
+        }
+        if (props?.hideIfEmpty !== true && props?.hideIfEmpty !== "true") {
+            resourceBindings.rammebetingelserKravTilByggegrunn = {
+                ...resourceBindings.rammebetingelserKravTilByggegrunn,
+                emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"
+            };
+        }
+        return resourceBindings;
+    }
+
+    /**
+     * Retrieves the component usage, which is an array of custom component names that this class utilizes.
+     *
+     * @returns {Array<string>} An array of custom component names used by this class.
+     */
+    getComponentUsage() {
+        return [
+            "custom-feedbacklist-validation-messages",
+            "custom-field-boolean-text",
+            "custom-header-text",
+            "custom-paragraph",
+            "custom-table-omraaderisiko"
+        ];
+    }
+}

--- a/src/classes/system-classes/component-classes/CustomGroupRammebetingelserKravTilByggegrunn.test.js
+++ b/src/classes/system-classes/component-classes/CustomGroupRammebetingelserKravTilByggegrunn.test.js
@@ -1,0 +1,66 @@
+import CustomGroupRammebetingelserKravTilByggegrunn from "./CustomGroupRammebetingelserKravTilByggegrunn";
+import KravTilByggegrunn from "../../data-classes/KravTilByggegrunn";
+
+jest.mock("@arkitektum/altinn-studio-custom-components-utils", () => ({
+    getTextResourceFromResourceBinding: jest.fn((key) => `text-for-${key}`),
+    hasValue: jest.fn((val) => val !== undefined && val !== null && val !== "")
+}));
+
+jest.mock("../../../functions/validations", () => ({
+    hasMissingTextResources: jest.fn(() => ["missing-resource"]),
+    hasValidationMessages: jest.fn((messages) => Array.isArray(messages) && messages.length > 0)
+}));
+
+jest.mock("../../../functions/helpers", () => ({
+    getComponentDataValue: jest.fn((props) => props?.formData || null)
+}));
+
+describe("CustomGroupRammebetingelserKravTilByggegrunn", () => {
+    afterEach(() => jest.clearAllMocks());
+
+    it("should initialize with correct properties when data and resources are provided", () => {
+        const props = {
+            formData: { harMiljoeforhold: true },
+            resourceValues: { title: "Custom Title" },
+            resourceBindings: { title: "custom.title", emptyFieldText: "custom.empty" }
+        };
+        const instance = new CustomGroupRammebetingelserKravTilByggegrunn(props);
+        expect(instance.isEmpty).toBe(false);
+        expect(instance.validationMessages).toEqual(["missing-resource"]);
+        expect(instance.hasValidationMessages).toBe(true);
+        expect(instance.resourceBindings.rammebetingelserKravTilByggegrunn.title).toBe("custom.title");
+        expect(instance.resourceBindings.rammebetingelserKravTilByggegrunn.emptyFieldText).toBe("custom.empty");
+        expect(instance.resourceValues.title).toBe("Custom Title");
+        expect(instance.resourceValues.data).toBeInstanceOf(KravTilByggegrunn);
+    });
+
+    it("should use default resource keys if not provided", () => {
+        const props = { formData: { harMiljoeforhold: false } };
+        const instance = new CustomGroupRammebetingelserKravTilByggegrunn(props);
+        expect(instance.resourceBindings.rammebetingelserKravTilByggegrunn.title).toBe("resource.kravTilByggegrunn.title");
+        expect(instance.resourceBindings.rammebetingelserKravTilByggegrunn.emptyFieldText).toBe("resource.emptyFieldText.default");
+    });
+
+    it("should omit title if hideTitle is true", () => {
+        const props = { hideTitle: true };
+        const instance = new CustomGroupRammebetingelserKravTilByggegrunn(props);
+        expect(instance.resourceBindings.rammebetingelserKravTilByggegrunn?.title).toBeUndefined();
+    });
+
+    it("should omit emptyFieldText if hideIfEmpty is true", () => {
+        const props = { hideIfEmpty: true };
+        const instance = new CustomGroupRammebetingelserKravTilByggegrunn(props);
+        expect(instance.resourceBindings.rammebetingelserKravTilByggegrunn?.emptyFieldText).toBeUndefined();
+    });
+
+    it("should return correct component usage", () => {
+        const instance = new CustomGroupRammebetingelserKravTilByggegrunn({});
+        expect(instance.getComponentUsage()).toEqual([
+            "custom-feedbacklist-validation-messages",
+            "custom-field-boolean-text",
+            "custom-header-text",
+            "custom-paragraph",
+            "custom-table-omraaderisiko"
+        ]);
+    });
+});

--- a/src/classes/system-classes/component-classes/CustomTableOmraaderisiko.js
+++ b/src/classes/system-classes/component-classes/CustomTableOmraaderisiko.js
@@ -120,22 +120,13 @@ export default class CustomTableOmraaderisiko extends CustomComponent {
     }
 
     /**
-     * Generates an object containing text resource bindings for various fields based on the provided props.
+     * Generates an object containing resource binding configurations for the component, providing default resource keys if specific bindings are not supplied via props.
      *
-     * @param {Object} props - The properties object.
-     * @param {Object} [props.resourceBindings] - Optional resource bindings for customizing text resources.
-     * @param {Object} [props.resourceBindings.risikotype] - Resource bindings for 'risikotype'.
-     * @param {string} [props.resourceBindings.risikotype.title] - Custom title for 'risikotype'.
-     * @param {string} [props.resourceBindings.risikotype.emptyFieldText] - Custom empty field text for 'risikotype'.
-     * @param {Object} [props.resourceBindings.sikkerhetsklasse] - Resource bindings for 'sikkerhetsklasse'.
-     * @param {string} [props.resourceBindings.sikkerhetsklasse.title] - Custom title for 'sikkerhetsklasse'.
-     * @param {string} [props.resourceBindings.sikkerhetsklasse.emptyFieldText] - Custom empty field text for 'sikkerhetsklasse'.
-     * @param {string} [props.resourceBindings.title] - Custom title for 'omraadeRisiko'.
-     * @param {string} [props.resourceBindings.description] - Custom description for 'omraadeRisiko'.
-     * @param {string} [props.resourceBindings.emptyFieldText] - Custom empty field text for 'omraadeRisiko'.
-     * @param {boolean|string} [props.hideTitle] - If true or "true", omraadeRisiko title is hidden.
-     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", omraadeRisiko empty field text is hidden.
-     * @returns {Object} An object containing text resource bindings for risikotype, sikkerhetsklasse, and optionally omraadeRisiko.
+     * @param {Object} props - The properties object containing optional resource bindings and flags.
+     * @param {Object} [props.resourceBindings] - Optional resource binding overrides for each component.
+     * @param {boolean|string} [props.hideTitle] - If true or "true", omits the title for the omraaderisiko table.
+     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", omits the emptyFieldText for the omraaderisiko table.
+     * @returns {Object} An object mapping component keys to their resource binding configurations.
      */
     getResourceBindings(props) {
         const resourceBindings = {
@@ -149,9 +140,6 @@ export default class CustomTableOmraaderisiko extends CustomComponent {
                     props?.resourceBindings?.sikkerhetsklasse?.title ||
                     "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.sikkerhetsklasse.title",
                 emptyFieldText: props?.resourceBindings?.sikkerhetsklasse?.emptyFieldText || "resource.emptyFieldText.default"
-            },
-            omraaderisiko: {
-                description: props?.resourceBindings?.description || "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.description"
             }
         };
         if (props?.hideTitle !== true && props?.hideTitle !== "true") {
@@ -175,6 +163,6 @@ export default class CustomTableOmraaderisiko extends CustomComponent {
      * @returns {Array<string>} An array of custom component names used by this class.
      */
     getComponentUsage() {
-        return ["custom-feedbacklist-validation-messages", "custom-field-data", "custom-header-text", "custom-table-data"];
+        return ["custom-feedbacklist-validation-messages", "custom-table-data"];
     }
 }

--- a/src/components/data-components/custom-group-rammebetingelser-krav-til-byggegrunn/index.js
+++ b/src/components/data-components/custom-group-rammebetingelser-krav-til-byggegrunn/index.js
@@ -1,0 +1,38 @@
+// Dependencies
+import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Global functions
+import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+
+// Local functions
+import { renderEmptyFieldText, renderHarMiljoeforholdElement, renderHeaderElement, renderOmraaderisiko } from "./renderers.js";
+
+export default customElements.define(
+    "custom-group-rammebetingelser-krav-til-byggegrunn",
+    class extends HTMLElement {
+        async connectedCallback() {
+            const component = instantiateComponent(this);
+            const componentContainerElement = getComponentContainerElement(this);
+            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
+                componentContainerElement.style.display = "none";
+            } else {
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
+                if (component?.isEmpty) {
+                    const emptyFieldTextElement = renderEmptyFieldText(component);
+                    this.appendChild(emptyFieldTextElement);
+                } else {
+                    this.appendChild(renderHarMiljoeforholdElement(component));
+                    this.appendChild(renderOmraaderisiko(component));
+                }
+            }
+            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+            if (feedbackListElement) {
+                this.appendChild(feedbackListElement);
+            }
+        }
+    }
+);

--- a/src/components/data-components/custom-group-rammebetingelser-krav-til-byggegrunn/renderers.js
+++ b/src/components/data-components/custom-group-rammebetingelser-krav-til-byggegrunn/renderers.js
@@ -1,0 +1,88 @@
+// Dependencies
+import { CustomElementHtmlAttributes, addContainerElement, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Global functions
+import { getAdjustedHeaderSize } from "../../../functions/helpers.js";
+
+/**
+ * Renders a custom header element with the specified title and size.
+ *
+ * @param {string} title - The title to display in the header element.
+ * @param {string} [size="h2"] - The size of the header element (e.g., "h1", "h2", "h3").
+ * @returns {HTMLElement} The created custom header element.
+ */
+export function renderHeaderElement(title, size = "h2") {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        size,
+        resourceValues: {
+            title
+        }
+    });
+    return createCustomElement("custom-header-text", htmlAttributes);
+}
+
+/**
+ * Renders a custom boolean field element for the "Har Miljøforhold" component.
+ *
+ * @param {Object} component - The component object containing resource values and bindings.
+ * @returns {HTMLElement} The created custom boolean field element.
+ */
+export function renderHarMiljoeforholdElement(component) {
+    const data = component?.resourceValues?.data;
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: true,
+        resourceBindings: {
+            title: component?.resourceBindings?.harMiljoeforhold?.title,
+            trueText: component?.resourceBindings?.harMiljoeforhold?.trueText,
+            falseText: component?.resourceBindings?.harMiljoeforhold?.falseText
+        },
+        resourceValues: {
+            data: data?.harMiljoeforhold
+        }
+    });
+    return addContainerElement(createCustomElement("custom-field-boolean-text", htmlAttributes));
+}
+
+/**
+ * Renders a custom table element for the "Områderisiko" component.
+ *
+ * @param {Object} component - The component object containing resource values and bindings.
+ * @returns {HTMLElement} The created custom table element.
+ */
+export function renderOmraaderisiko(component) {
+    const data = component?.resourceValues?.data?.muligeOmraadeRisikoer?.omraadeRisiko;
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: true,
+        hideTitle: false,
+        size: getAdjustedHeaderSize(component?.size || "h2", 1),
+        resourceBindings: {
+            title: component?.resourceBindings?.omraaderisiko?.title,
+            description: component?.resourceBindings?.omraaderisiko?.description
+        },
+        resourceValues: {
+            data
+        }
+    });
+    return createCustomElement("custom-table-omraaderisiko", htmlAttributes);
+}
+
+/**
+ * Renders a custom paragraph element displaying the empty field text for a given component.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {string} [component.resourceValues.data] - The text to display as the empty field.
+ * @returns {HTMLElement} The custom paragraph element with the specified attributes.
+ */
+export function renderEmptyFieldText(component) {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        resourceValues: {
+            title: component?.resourceValues?.data
+        }
+    });
+    return addContainerElement(createCustomElement("custom-paragraph", htmlAttributes));
+}

--- a/src/components/data-components/custom-table-omraaderisiko/index.js
+++ b/src/components/data-components/custom-table-omraaderisiko/index.js
@@ -1,13 +1,10 @@
-// Dependencies
-import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
-
 // Global functions
 import { getComponentContainerElement } from "../../../functions/helpers.js";
 import { instantiateComponent } from "../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
 
 // Local functions
-import { renderHeaderElement, renderOmraaderisikoTable } from "./renderers.js";
+import { renderOmraaderisikoTable } from "./renderers.js";
 
 // Stylesheet
 import "./styles.css" with { type: "css" };
@@ -21,9 +18,6 @@ export default customElements.define(
             if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
                 componentContainerElement.style.display = "none";
             } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
                 const omraaderisikoTableElement = renderOmraaderisikoTable(component);
                 this.appendChild(omraaderisikoTableElement);
             }

--- a/src/components/data-components/custom-table-omraaderisiko/renderers.js
+++ b/src/components/data-components/custom-table-omraaderisiko/renderers.js
@@ -1,27 +1,6 @@
 // Dependencies
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
-// Global functions
-import { getAdjustedHeaderSize } from "../../../functions/helpers.js";
-
-/**
- * Renders a custom header element with the specified title and size.
- *
- * @param {string} title - The text to display in the header.
- * @param {string} [size="h2"] - The size of the header (e.g., "h1", "h2", etc.).
- * @returns {HTMLElement} The created custom header element.
- */
-export function renderHeaderElement(title, size = "h2") {
-    const htmlAttributes = new CustomElementHtmlAttributes({
-        isChildComponent: true,
-        size,
-        resourceValues: {
-            title
-        }
-    });
-    return createCustomElement("custom-header-text", htmlAttributes);
-}
-
 /**
  * Renders a custom table for "Omraaderisiko" with specified columns and attributes.
  *
@@ -59,14 +38,14 @@ export function renderOmraaderisikoTable(component) {
         }
     ];
     const htmlAttributes = new CustomElementHtmlAttributes({
-        size: getAdjustedHeaderSize(component?.size, 1),
+        size: component?.size || "h2",
         hideIfEmpty: true,
         isChildComponent: true,
         resourceValues: {
             data: component?.resourceValues?.data
         },
         resourceBindings: {
-            title: component?.resourceBindings?.omraaderisiko?.description
+            title: component?.resourceBindings?.omraaderisiko?.title
         },
         tableColumns
     });

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -35,6 +35,7 @@ import customGroupKontrollErklaeringer from "./data-components/custom-group-kont
 import customGroupLoefteinnretninger from "./data-components/custom-group-loefteinnretninger/index.js";
 import customGroupNaboGjenboerEiendom from "./data-components/custom-grouplist-nabo-gjenboer-eiendom/custom-group-nabo-gjenboer-eiendom/index.js";
 import customGroupOvervann from "./data-components/custom-group-overvann/index.js";
+import customGroupRammebetingelserKravTilByggegrunn from "./data-components/custom-group-rammebetingelser-krav-til-byggegrunn/index.js";
 import customGroupRammebetingelserTilknytninger from "./data-components/custom-group-rammebetingelser-tilknytninger/index.js";
 import customGroupSamsvarAnsvarsomraade from "./data-components/custom-grouplist-samsvar-ansvarsomraade/custom-group-samsvar-ansvarsomraade/index.js";
 import customGroupSamsvarErklaeringer from "./data-components/custom-group-samsvar-erklaeringer/index.js";
@@ -126,6 +127,7 @@ export {
     customGroupKontrollErklaeringer,
     customGroupNaboGjenboerEiendom,
     customGroupOvervann,
+    customGroupRammebetingelserKravTilByggegrunn,
     customGroupRammebetingelserTilknytninger,
     customGroupSamsvarAnsvarsomraade,
     customGroupSamsvarErklaeringer,

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -62,10 +62,6 @@
             "value": "Begrunnelse"
         },
         {
-            "id": "resource.rammebetingelser.kravTilByggegrunn.harMiljoeforhold.title",
-            "value": "Har tiltaket andre naturforhold jf. pbl §28-1?"
-        },
-        {
             "id": "resource.begrunnelse.hensynBakBestemmelsen.title",
             "value": "Hensynet bak bestemmelse"
         },
@@ -450,8 +446,12 @@
             "value": "Arbeidene vil bli utført innen"
         },
         {
-            "id": "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.description",
-            "value": "Oversikt over områderisikoer der byggverket skal plasseres"
+            "id": "resource.kravTilByggegrunn.title",
+            "value": "Krav til byggegrunn"
+        },
+        {
+            "id": "resource.rammebetingelser.kravTilByggegrunn.harMiljoeforhold.title",
+            "value": "Har tiltaket andre naturforhold jf. pbl §28-1?"
         },
         {
             "id": "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.risikotype.title",
@@ -463,7 +463,7 @@
         },
         {
             "id": "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.title",
-            "value": "Krav til byggegrunn"
+            "value": "Oversikt over områderisikoer der byggverket skal plasseres"
         },
         {
             "id": "resource.merknaderNabovarsel.header",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -90,12 +90,6 @@
         }
     },
     {
-        "id": "resource.rammebetingelser.kravTilByggegrunn.harMiljoeforhold.title",
-        "values": {
-            "nb": "Har tiltaket andre naturforhold jf. pbl §28-1?"
-        }
-    },
-    {
         "id": "resource.begrunnelse.hensynBakBestemmelsen.title",
         "values": {
             "nb": "Hensynet bak bestemmelse"
@@ -672,9 +666,15 @@
         }
     },
     {
-        "id": "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.description",
+        "id": "resource.kravTilByggegrunn.title",
         "values": {
-            "nb": "Oversikt over områderisikoer der byggverket skal plasseres"
+            "nb": "Krav til byggegrunn"
+        }
+    },
+    {
+        "id": "resource.rammebetingelser.kravTilByggegrunn.harMiljoeforhold.title",
+        "values": {
+            "nb": "Har tiltaket andre naturforhold jf. pbl §28-1?"
         }
     },
     {
@@ -692,7 +692,7 @@
     {
         "id": "resource.kravTilByggegrunn.muligeOmraadeRisikoer.omraadeRisiko.title",
         "values": {
-            "nb": "Krav til byggegrunn"
+            "nb": "Oversikt over områderisikoer der byggverket skal plasseres"
         }
     },
     {

--- a/src/functions/componentHelpers.js
+++ b/src/functions/componentHelpers.js
@@ -33,6 +33,7 @@ import CustomGroupKontrollErklaeringer from "../classes/system-classes/component
 import CustomGroupLoefteinnretninger from "../classes/system-classes/component-classes/CustomGroupLoefteinnretninger.js";
 import CustomGroupNaboGjenboerEiendom from "../classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.js";
 import CustomGroupOvervann from "../classes/system-classes/component-classes/CustomGroupOvervann.js";
+import CustomGroupRammebetingelserKravTilByggegrunn from "../classes/system-classes/component-classes/CustomGroupRammebetingelserKravTilByggegrunn.js";
 import CustomGroupRammebetingelserTilknytninger from "../classes/system-classes/component-classes/CustomGroupRammebetingelserTilknytninger.js";
 import CustomGroupSamsvarAnsvarsomraade from "../classes/system-classes/component-classes/CustomGroupSamsvarAnsvarsomraade.js";
 import CustomGroupSamsvarErklaeringer from "../classes/system-classes/component-classes/CustomGroupSamsvarErklaeringer.js";
@@ -113,6 +114,7 @@ export function getComponentForTagName(tagName) {
         "custom-group-loefteinnretninger": CustomGroupLoefteinnretninger,
         "custom-group-nabo-gjenboer-eiendom": CustomGroupNaboGjenboerEiendom,
         "custom-group-overvann": CustomGroupOvervann,
+        "custom-group-rammebetingelser-krav-til-byggegrunn": CustomGroupRammebetingelserKravTilByggegrunn,
         "custom-group-rammebetingelser-tilknytninger": CustomGroupRammebetingelserTilknytninger,
         "custom-group-samsvar-ansvarsomraade": CustomGroupSamsvarAnsvarsomraade,
         "custom-group-samsvar-erklaeringer": CustomGroupSamsvarErklaeringer,


### PR DESCRIPTION
Introduces a new custom group component for displaying building ground requirements, refines related data models, and refactors table header rendering.

This pull request provides a structured display for building ground requirements by adding a new custom group component, updating data models to support boolean environmental conditions and multiple area risks, and adjusting header rendering responsibilities for nested components.

### Changes

- **New Component**: Added `CustomGroupRammebetingelserKravTilByggegrunn` (system and data component classes, renderers) to display `KravTilByggegrunn` data, including environmental conditions and area risks.
- **Data Model Refinement (`KravTilByggegrunn`)**: Renamed the `miljoeforhold` property from a `string` to `harMiljoeforhold` of type `boolean`.
- **Data Model Refinement (`MuligeOmraadeRisikoer`)**: Modified the `omraadeRisiko` property to accept and process an `Array` of area risks, rather than a single object, mapping each item to an `Omraaderisiko` instance.
- **Component Refactoring (`CustomTableOmraaderisiko`)**: Removed the component's internal logic for rendering its own header, shifting this responsibility to its parent. Its `getResourceBindings` and `getComponentUsage` methods were updated accordingly, and the `resourceBindings.omraaderisiko.description` key was repurposed to `resourceBindings.omraaderisiko.title`.
- **Resource File Updates**: Added new text resources for "Krav til byggegrunn" and adjusted existing resource IDs and values to align with the data model and component changes.

### Impact

- **Behavioral Changes**: The display and data structure for "Krav til byggegrunn" are significantly altered, now supporting a dedicated group component, a boolean indicator for environmental conditions, and the display of multiple area risks in a table.
- **Dependencies Affected**: Code consuming `KravTilByggegrunn` or `MuligeOmraadeRisikoer` will need to adapt to the changed property names and data types (string to boolean, single object to array). `CustomTableOmraaderisiko` now relies on its parent component to provide its main title.
- **Breaking Changes**:
  - Direct usage of `KravTilByggegrunn.miljoeforhold` will break; it must be updated to `harMiljoeforhold` and expect a boolean.
  - Direct instantiation of `MuligeOmraadeRisikoer` expecting a single `omraadeRisiko` object will break; it now expects an array.
  - Any direct consumers of `CustomTableOmraaderisiko` that relied on it rendering its own header will need to be updated to provide that header externally.