### PR TITLE
Exclude simpleBinding from formData in CustomTableAnsvarsrettAnsvarsomraade

### DIFF
--- a/src/classes/system-classes/component-classes/CustomTableAnsvarsrettAnsvarsomraade.js
+++ b/src/classes/system-classes/component-classes/CustomTableAnsvarsrettAnsvarsomraade.js
@@ -58,7 +58,9 @@ export default class CustomTableAnsvarsrettAnsvarsomraade extends CustomComponen
      * @returns {Array} The list of "ansvarsomraade" values extracted from the form data.
      */
     getValueFromFormData(props, resourceBindings) {
-        const { ...formDataWithoutSimpleBinding } = props.formData ?? {};
+        // eslint-disable-next-line no-unused-vars
+        const { simpleBinding: _simpleBinding, ...formDataWithoutSimpleBinding } = props.formData ?? {};
+
         const cleanedProps = {
             ...props,
             formData: formDataWithoutSimpleBinding

--- a/src/classes/system-classes/component-classes/CustomTableAnsvarsrettAnsvarsomraade.js
+++ b/src/classes/system-classes/component-classes/CustomTableAnsvarsrettAnsvarsomraade.js
@@ -58,14 +58,9 @@ export default class CustomTableAnsvarsrettAnsvarsomraade extends CustomComponen
      * @returns {Array} The list of "ansvarsomraade" values extracted from the form data.
      */
     getValueFromFormData(props, resourceBindings) {
-        // eslint-disable-next-line no-unused-vars
-        const { simpleBinding: _simpleBinding, ...formDataWithoutSimpleBinding } = props.formData ?? {};
-
-        const cleanedProps = {
-            ...props,
-            formData: formDataWithoutSimpleBinding
-        };
-        const data = getComponentDataValue(cleanedProps);
+        const formDataWithoutSimpleBinding = { ...props.formData };
+        delete formDataWithoutSimpleBinding.simpleBinding;
+        const data = getComponentDataValue({ ...props, formData: formDataWithoutSimpleBinding });
         const ansvarsomraadeList = this.getAnsvarsomraadeListFromData(data, resourceBindings);
         return ansvarsomraadeList;
     }


### PR DESCRIPTION
Corrects the destructuring logic to explicitly remove the simpleBinding property from form data, ensuring it is not included in the extracted values.

FT-1696
