### PR TITLE
Feature/ft 1645

### DIFF
--- a/src/classes/system-classes/component-classes/CustomGroupSjekklistekravHeaderText.js
+++ b/src/classes/system-classes/component-classes/CustomGroupSjekklistekravHeaderText.js
@@ -1,0 +1,69 @@
+// Dependencies
+import { getTextResourceFromResourceBinding, hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Classes
+import CustomComponent from "../CustomComponent.js";
+
+export default class CustomGroupSjekklistekravHeaderText extends CustomComponent {
+    constructor(props) {
+        super(props);
+        const resourceBindings = this.getResourceBindings(props);
+        const data = this.getValueFromResourceBindings(resourceBindings);
+
+        const isEmpty = !this.hasContent(data);
+
+        this.isEmpty = isEmpty;
+        this.resourceBindings = resourceBindings?.sjekklistekravHeader || {};
+        this.resourceValues = {
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.sjekklistekravHeader?.emptyFieldText) : data
+        };
+    }
+
+    /**
+     * Checks if the provided data has a value.
+     *
+     * @param {*} data - The data to check for content.
+     * @returns {boolean} Returns true if the data has a value, otherwise false.
+     */
+    hasContent(data) {
+        return hasValue(data);
+    }
+
+    /**
+     * Retrieves the values from the resource bindings.
+     *
+     * @param {Object} resourceBindings - The resource bindings object.
+     * @returns {Object} An object containing the values from the resource bindings.
+     */
+    getValueFromResourceBindings(resourceBindings) {
+        return {
+            sjekklistepunkt: getTextResourceFromResourceBinding(resourceBindings?.sjekklistekravHeader?.sjekklistepunkt),
+            sjekklistepunktsvar: getTextResourceFromResourceBinding(resourceBindings?.sjekklistekravHeader?.sjekklistepunktsvar)
+        };
+    }
+
+    /**
+     * Retrieves the resource bindings for the component based on the provided props.
+     *
+     * @param {Object} props - The properties object containing resource bindings.
+     * @returns {Object} An object containing the resource bindings for the component.
+     */
+    getResourceBindings(props) {
+        const resourceBindings = {
+            sjekklistepunkt: props?.resourceBindings?.sjekklistepunkt,
+            sjekklistepunktsvar: props?.resourceBindings?.sjekklistepunktsvar
+        };
+        return {
+            sjekklistekravHeader: resourceBindings
+        };
+    }
+
+    /**
+     * Retrieves the component usage, which is an array of custom component names that this class utilizes.
+     *
+     * @returns {Array<string>} An array of custom component names used by this class.
+     */
+    getComponentUsage() {
+        return ["custom-field"];
+    }
+}

--- a/src/classes/system-classes/component-classes/CustomGroupSjekklistekravHeaderText.test.js
+++ b/src/classes/system-classes/component-classes/CustomGroupSjekklistekravHeaderText.test.js
@@ -1,0 +1,325 @@
+import { getTextResourceFromResourceBinding, hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+import CustomComponent from "../CustomComponent";
+import CustomGroupSjekklistekravHeaderText from "./CustomGroupSjekklistekravHeaderText";
+
+// Mock the utility functions
+jest.mock("@arkitektum/altinn-studio-custom-components-utils", () => ({
+    getTextResourceFromResourceBinding: jest.fn(),
+    hasValue: jest.fn()
+}));
+
+describe("CustomGroupSjekklistekravHeaderText", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("constructor", () => {
+        it("should extend CustomComponent", () => {
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+            expect(instance).toBeInstanceOf(CustomComponent);
+        });
+
+        it("should initialize with empty props", () => {
+            hasValue.mockReturnValue(false);
+            getTextResourceFromResourceBinding.mockReturnValue("Empty field text");
+
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            expect(instance.isEmpty).toBe(true);
+            expect(instance.resourceBindings).toEqual({});
+            expect(instance.resourceValues).toEqual({
+                data: "Empty field text"
+            });
+        });
+
+        it("should initialize with valid resource bindings when data has content", () => {
+            hasValue.mockReturnValue(true);
+            getTextResourceFromResourceBinding.mockReturnValueOnce("Checklist item").mockReturnValueOnce("Checklist answer");
+
+            const props = {
+                resourceBindings: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: "answer_binding"
+                }
+            };
+
+            const instance = new CustomGroupSjekklistekravHeaderText(props);
+
+            expect(instance.isEmpty).toBe(false);
+            expect(instance.resourceBindings).toEqual({
+                sjekklistepunkt: "item_binding",
+                sjekklistepunktsvar: "answer_binding"
+            });
+            expect(instance.resourceValues).toEqual({
+                data: {
+                    sjekklistepunkt: "Checklist item",
+                    sjekklistepunktsvar: "Checklist answer"
+                }
+            });
+        });
+
+        it("should handle empty resource bindings when data is empty", () => {
+            hasValue.mockReturnValue(false);
+            getTextResourceFromResourceBinding
+                .mockReturnValueOnce(undefined) // sjekklistepunkt
+                .mockReturnValueOnce(undefined) // sjekklistepunktsvar
+                .mockReturnValueOnce("Empty text"); // emptyFieldText
+
+            const props = {
+                resourceBindings: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: "answer_binding"
+                }
+            };
+
+            const instance = new CustomGroupSjekklistekravHeaderText(props);
+
+            expect(instance.isEmpty).toBe(true);
+            // The emptyFieldText call returns the mocked "Empty text"
+            expect(instance.resourceValues.data).toBe("Empty text");
+        });
+
+        it("should handle missing resource bindings gracefully", () => {
+            hasValue.mockReturnValue(false);
+            getTextResourceFromResourceBinding.mockReturnValue(undefined);
+
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            expect(instance.isEmpty).toBe(true);
+            expect(instance.resourceBindings).toEqual({});
+            expect(instance.resourceValues.data).toBeUndefined();
+        });
+    });
+
+    describe("hasContent", () => {
+        it("should return true when data has value", () => {
+            hasValue.mockReturnValue(true);
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            const result = instance.hasContent("some data");
+
+            expect(hasValue).toHaveBeenCalledWith("some data");
+            expect(result).toBe(true);
+        });
+
+        it("should return false when data has no value", () => {
+            hasValue.mockReturnValue(false);
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            const result = instance.hasContent("");
+
+            expect(hasValue).toHaveBeenCalledWith("");
+            expect(result).toBe(false);
+        });
+
+        it("should handle null and undefined data", () => {
+            hasValue.mockReturnValue(false);
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            expect(instance.hasContent(null)).toBe(false);
+            expect(instance.hasContent(undefined)).toBe(false);
+            expect(hasValue).toHaveBeenCalledWith(null);
+            expect(hasValue).toHaveBeenCalledWith(undefined);
+        });
+    });
+
+    describe("getValueFromResourceBindings", () => {
+        let instance;
+
+        beforeEach(() => {
+            // Create instance with minimal mocking to avoid interference
+            hasValue.mockReturnValue(false);
+            getTextResourceFromResourceBinding.mockReturnValue(undefined);
+            instance = new CustomGroupSjekklistekravHeaderText({});
+            jest.clearAllMocks(); // Clear mocks after constructor is done
+        });
+
+        it("should extract values from valid resource bindings", () => {
+            getTextResourceFromResourceBinding.mockReturnValueOnce("Item text").mockReturnValueOnce("Answer text");
+
+            const resourceBindings = {
+                sjekklistekravHeader: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: "answer_binding"
+                }
+            };
+
+            const result = instance.getValueFromResourceBindings(resourceBindings);
+
+            expect(getTextResourceFromResourceBinding).toHaveBeenCalledWith("item_binding");
+            expect(getTextResourceFromResourceBinding).toHaveBeenCalledWith("answer_binding");
+            expect(result).toEqual({
+                sjekklistepunkt: "Item text",
+                sjekklistepunktsvar: "Answer text"
+            });
+        });
+
+        it("should handle missing resource bindings", () => {
+            getTextResourceFromResourceBinding.mockReturnValue(undefined);
+
+            const result = instance.getValueFromResourceBindings({});
+
+            expect(result).toEqual({
+                sjekklistepunkt: undefined,
+                sjekklistepunktsvar: undefined
+            });
+        });
+
+        it("should handle undefined resource bindings", () => {
+            getTextResourceFromResourceBinding.mockReturnValue(undefined);
+
+            const result = instance.getValueFromResourceBindings(undefined);
+
+            expect(result).toEqual({
+                sjekklistepunkt: undefined,
+                sjekklistepunktsvar: undefined
+            });
+        });
+
+        it("should handle partial resource bindings", () => {
+            getTextResourceFromResourceBinding.mockReturnValueOnce("Item text").mockReturnValueOnce(undefined);
+
+            const resourceBindings = {
+                sjekklistekravHeader: {
+                    sjekklistepunkt: "item_binding"
+                    // sjekklistepunktsvar is missing
+                }
+            };
+
+            const result = instance.getValueFromResourceBindings(resourceBindings);
+
+            expect(result).toEqual({
+                sjekklistepunkt: "Item text",
+                sjekklistepunktsvar: undefined
+            });
+        });
+    });
+
+    describe("getResourceBindings", () => {
+        it("should extract resource bindings from props", () => {
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+            const props = {
+                resourceBindings: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: "answer_binding",
+                    otherProperty: "should_be_ignored"
+                }
+            };
+
+            const result = instance.getResourceBindings(props);
+
+            expect(result).toEqual({
+                sjekklistekravHeader: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: "answer_binding"
+                }
+            });
+        });
+
+        it("should handle missing resource bindings in props", () => {
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+            const props = {};
+
+            const result = instance.getResourceBindings(props);
+
+            expect(result).toEqual({
+                sjekklistekravHeader: {
+                    sjekklistepunkt: undefined,
+                    sjekklistepunktsvar: undefined
+                }
+            });
+        });
+
+        it("should handle undefined props", () => {
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            const result = instance.getResourceBindings(undefined);
+
+            expect(result).toEqual({
+                sjekklistekravHeader: {
+                    sjekklistepunkt: undefined,
+                    sjekklistepunktsvar: undefined
+                }
+            });
+        });
+
+        it("should handle partial resource bindings in props", () => {
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+            const props = {
+                resourceBindings: {
+                    sjekklistepunkt: "item_binding"
+                    // sjekklistepunktsvar is missing
+                }
+            };
+
+            const result = instance.getResourceBindings(props);
+
+            expect(result).toEqual({
+                sjekklistekravHeader: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: undefined
+                }
+            });
+        });
+    });
+
+    describe("getComponentUsage", () => {
+        it("should return array with custom-field component", () => {
+            const instance = new CustomGroupSjekklistekravHeaderText({});
+
+            const result = instance.getComponentUsage();
+
+            expect(result).toEqual(["custom-field"]);
+        });
+
+        it("should always return the same component usage", () => {
+            const instance1 = new CustomGroupSjekklistekravHeaderText({});
+            const instance2 = new CustomGroupSjekklistekravHeaderText({ someProps: "value" });
+
+            expect(instance1.getComponentUsage()).toEqual(["custom-field"]);
+            expect(instance2.getComponentUsage()).toEqual(["custom-field"]);
+        });
+    });
+
+    describe("integration scenarios", () => {
+        it("should handle complete workflow with valid data", () => {
+            hasValue.mockReturnValue(true);
+            getTextResourceFromResourceBinding.mockReturnValueOnce("Complete item").mockReturnValueOnce("Complete answer");
+
+            const props = {
+                resourceBindings: {
+                    sjekklistepunkt: "item_binding",
+                    sjekklistepunktsvar: "answer_binding"
+                }
+            };
+
+            const instance = new CustomGroupSjekklistekravHeaderText(props);
+
+            expect(instance.isEmpty).toBe(false);
+            expect(instance.getComponentUsage()).toEqual(["custom-field"]);
+            expect(instance.resourceValues.data).toEqual({
+                sjekklistepunkt: "Complete item",
+                sjekklistepunktsvar: "Complete answer"
+            });
+        });
+
+        it("should handle complete workflow with empty data", () => {
+            hasValue.mockReturnValue(false);
+            getTextResourceFromResourceBinding.mockReturnValue("No data available");
+
+            const props = {
+                resourceBindings: {
+                    sjekklistekravHeader: {
+                        emptyFieldText: "empty_text"
+                    }
+                }
+            };
+
+            const instance = new CustomGroupSjekklistekravHeaderText(props);
+
+            expect(instance.isEmpty).toBe(true);
+            expect(instance.getComponentUsage()).toEqual(["custom-field"]);
+            expect(instance.resourceValues.data).toBe("No data available");
+        });
+    });
+});

--- a/src/classes/system-classes/component-classes/CustomGrouplistSjekklistekrav.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistSjekklistekrav.js
@@ -42,9 +42,18 @@ export default class CustomGrouplistSjekklistekrav extends CustomComponent {
         this.isEmpty = isEmpty;
         this.validationMessages = validationMessages;
         this.hasValidationMessages = hasValidationMessages(validationMessages);
-        this.resourceBindings = resourceBindings?.sjekklistekrav || {};
+        this.resourceBindings = resourceBindings?.sjekklistekrav
+            ? {
+                  sjekklistepunkt: resourceBindings?.sjekklistekrav?.sjekklistepunkt,
+                  sjekklistepunktsvar: resourceBindings?.sjekklistekrav?.sjekklistepunktsvar,
+                  trueText: resourceBindings?.sjekklistekrav?.trueText,
+                  falseText: resourceBindings?.sjekklistekrav?.falseText,
+                  defaultText: resourceBindings?.sjekklistekrav?.defaultText
+              }
+            : {};
         this.resourceValues = {
             title: getTextResourceFromResourceBinding(resourceBindings?.sjekklistekrav?.title),
+            description: getTextResourceFromResourceBinding(resourceBindings?.sjekklistekrav?.description),
             data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.sjekklistekrav?.emptyFieldText) : data
         };
     }
@@ -84,25 +93,22 @@ export default class CustomGrouplistSjekklistekrav extends CustomComponent {
     }
 
     /**
-     * Generates resource bindings for a component based on provided props.
+     * Generates resource bindings for the component based on provided props, including default values for trueText, falseText, and defaultText.
      *
-     * @param {Object} props - The properties object.
-     * @param {Object} [props.resourceBindings] - Optional resource bindings overrides.
-     * @param {string} [props.resourceBindings.trueText] - Text to display for true value.
-     * @param {string} [props.resourceBindings.falseText] - Text to display for false value.
-     * @param {string} [props.resourceBindings.defaultText] - Default text to display.
-     * @param {string} [props.resourceBindings.title] - Title text for the component.
-     * @param {string} [props.resourceBindings.emptyFieldText] - Text to display when field is empty.
-     * @param {boolean|string} [props.hideTitle] - If true or "true", hides the title.
-     * @param {boolean|string} [props.hideIfEmpty] - If true or "true", hides the empty field text.
+     * @param {Object} props - The properties containing resource bindings.
      * @returns {Object} An object containing the resource bindings for the sjekklistekrav component.
      */
     getResourceBindings(props) {
         const resourceBindings = {
             trueText: props?.resourceBindings?.trueText || "resource.trueText.default",
             falseText: props?.resourceBindings?.falseText || "resource.falseText.default",
-            defaultText: props?.resourceBindings?.defaultText || "resource.emptyFieldText.default"
+            defaultText: props?.resourceBindings?.defaultText || "resource.emptyFieldText.default",
+            sjekklistepunkt: props?.resourceBindings?.sjekklistepunkt,
+            sjekklistepunktsvar: props?.resourceBindings?.sjekklistepunktsvar
         };
+        if (props?.resourceBindings?.description?.length > 0) {
+            resourceBindings.description = props?.resourceBindings?.description;
+        }
         if (props?.hideTitle !== true && props?.hideTitle !== "true") {
             resourceBindings.title = props?.resourceBindings?.title || "resource.krav.sjekklistekrav.title";
         }
@@ -120,6 +126,13 @@ export default class CustomGrouplistSjekklistekrav extends CustomComponent {
      * @returns {Array<string>} An array of custom component names used by this class.
      */
     getComponentUsage() {
-        return ["custom-divider", "custom-feedbacklist-validation-messages", "custom-group-sjekklistekrav", "custom-header-text", "custom-paragraph"];
+        return [
+            "custom-divider",
+            "custom-feedbacklist-validation-messages",
+            "custom-group-sjekklistekrav",
+            "custom-group-sjekklistekrav-header-text",
+            "custom-header-text",
+            "custom-paragraph"
+        ];
     }
 }

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/index.js
@@ -2,7 +2,6 @@
 import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
 import { getComponentContainerElement } from "../../../../functions/helpers.js";
 import { instantiateComponent } from "../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
 
 // Local functions
 import { renderSjekklistepunkHeader } from "./renderers.js";

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/index.js
@@ -1,0 +1,36 @@
+// Global functions
+import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
+import { getComponentContainerElement } from "../../../../functions/helpers.js";
+import { instantiateComponent } from "../../../../functions/componentHelpers.js";
+import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
+
+// Local functions
+import { renderSjekklistepunkHeader } from "./renderers.js";
+
+// Stylesheet
+import "./styles.css" with { type: "css" };
+
+export default customElements.define(
+    "custom-group-sjekklistekrav-header-text",
+    class extends HTMLElement {
+        async connectedCallback() {
+            const component = instantiateComponent(this);
+            const componentContainerElement = getComponentContainerElement(this);
+            if (component.isEmpty) {
+                if (isDevMode()) {
+                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
+                    if (hiddenEl) this.appendChild(hiddenEl);
+                } else if (componentContainerElement) {
+                    componentContainerElement.style.display = "none";
+                } else {
+                    this.style.display = "none";
+                }
+            } else {
+                const containerElement = document.createElement("div");
+                containerElement.appendChild(renderSjekklistepunkHeader(component));
+                this.appendChild(containerElement);
+                addDevToolsOverlay(this, component, "data");
+            }
+        }
+    }
+);

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/renderers.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/renderers.js
@@ -1,0 +1,76 @@
+// Dependencies
+import { CustomElementHtmlAttributes, addContainerElement, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Global functions
+import { renderLayoutContainerElement } from "../../../../functions/helpers.js";
+
+/**
+ * Renders the text header component for a checklist item.
+ * Creates a custom field element with the checklist item title spanning 11 columns.
+ *
+ * @param {Object} component - The component object containing resource values and configuration
+ * @param {Object} [component.resourceValues] - Resource values for the component
+ * @param {Object} [component.resourceValues.data] - Data containing checklist item values
+ * @param {string} [component.resourceValues.data.sjekklistepunkt] - The checklist item text
+ * @param {boolean} [component.enableLinks] - Whether to enable links in the component
+ * @returns {HTMLElement} A container element with the custom field for the checklist item text
+ */
+export function renderSjekklistepunkTextHeader(component) {
+    const data = component?.resourceValues?.data;
+    const grid = { xs: 11 };
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: false,
+        hideTitle: false,
+        enableLinks: component?.enableLinks,
+        grid,
+        resourceValues: {
+            title: data?.sjekklistepunkt
+        }
+    });
+    return addContainerElement(createCustomElement("custom-field", htmlAttributes), grid);
+}
+
+/**
+ * Renders the value header component for a checklist item.
+ * Creates a custom field element with the checklist item answer title spanning 1 column.
+ *
+ * @param {Object} component - The component object containing resource values and configuration
+ * @param {Object} [component.resourceValues] - Resource values for the component
+ * @param {Object} [component.resourceValues.data] - Data containing checklist item values
+ * @param {string} [component.resourceValues.data.sjekklistepunktsvar] - The checklist item answer text
+ * @returns {HTMLElement} A container element with the custom field for the checklist item value
+ */
+export function renderSjekklistepunkValueHeader(component) {
+    const data = component?.resourceValues?.data;
+    const grid = { xs: 1 };
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: false,
+        hideTitle: false,
+        grid,
+        resourceValues: {
+            title: data?.sjekklistepunktsvar
+        }
+    });
+    return addContainerElement(createCustomElement("custom-field", htmlAttributes), grid);
+}
+
+/**
+ * Renders the complete header for a checklist item.
+ * Combines both the text header and value header components in a layout container.
+ *
+ * @param {Object} component - The component object containing resource values and configuration
+ * @param {Object} [component.resourceValues] - Resource values for the component
+ * @param {Object} [component.resourceValues.data] - Data containing checklist item values
+ * @param {string} [component.resourceValues.data.sjekklistepunkt] - The checklist item text
+ * @param {string} [component.resourceValues.data.sjekklistepunktsvar] - The checklist item answer text
+ * @param {boolean} [component.enableLinks] - Whether to enable links in the component
+ * @returns {HTMLElement} A layout container element containing both header components
+ */
+export function renderSjekklistepunkHeader(component) {
+    const containerElement = renderLayoutContainerElement();
+    containerElement.appendChild(renderSjekklistepunkTextHeader(component));
+    containerElement.appendChild(renderSjekklistepunkValueHeader(component));
+    return containerElement;
+}

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/styles.css
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/styles.css
@@ -1,0 +1,9 @@
+custom-group-sjekklistekrav-header-text {
+    & > div {
+        padding: 0 10px;
+        background-color: var(--color-default-default);
+        border-bottom: 1px solid var(--color-default-dark);
+        font-weight: var(--font-weight-bold);
+        hyphens: auto;
+    }
+}

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/renderers.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/renderers.js
@@ -45,6 +45,9 @@ export function renderSjekklistepunkText(component) {
         resourceValues: {
             title: data?.sjekklistepunkt?.kodebeskrivelse,
             data: data?.dokumentasjon
+        },
+        styleOverride: {
+            paddingRight: "10px"
         }
     });
     return addContainerElement(createCustomElement("custom-field", htmlAttributes), grid);

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/index.js
@@ -8,7 +8,13 @@ import { instantiateComponent } from "../../../functions/componentHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
 
 // Local functions
-import { renderDivider, renderEmptyFieldText, renderHeaderElement, renderSjekklistekravGroup } from "./renderers.js";
+import {
+    renderDivider,
+    renderEmptyFieldText,
+    renderHeaderElement,
+    renderSjekklistekravGroup,
+    renderSjekklistekravGroupListHeader
+} from "./renderers.js";
 
 // Stylesheet
 import "./styles.css" with { type: "css" };
@@ -36,6 +42,11 @@ export default customElements.define(
                 }
                 const sjekklistekravListElement = document.createElement("div");
                 sjekklistekravListElement.className = "sjekklistekrav-list";
+
+                const sjekklistekravGroupListHeaderElement = renderSjekklistekravGroupListHeader(component);
+                if (sjekklistekravGroupListHeaderElement) {
+                    sjekklistekravListElement.appendChild(sjekklistekravGroupListHeaderElement);
+                }
                 for (const sjekklistekrav of component?.resourceValues?.data ?? []) {
                     const sjekklistekravElement = renderSjekklistekravGroup(sjekklistekrav, component);
                     sjekklistekravListElement.appendChild(sjekklistekravElement);

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/renderers.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/renderers.js
@@ -20,6 +20,31 @@ export function renderHeaderElement(title, size = "h2") {
 }
 
 /**
+ * Renders a custom group list header element for "sjekklistekrav" (checklist requirements).
+ *
+ * @param {Object} component - The component configuration object.
+ * @param {Object} [component.resourceBindings] - Resource bindings for text values.
+ * @param {string} [component.resourceBindings.sjekklistepunkt] - Text to display for checklist points.
+ * @param {string} [component.resourceBindings.sjekklistepunktsvar] - Text to display for checklist point answers.
+ * @returns {HTMLElement|null} The custom group list header element or null if required bindings are missing.
+ */
+export function renderSjekklistekravGroupListHeader(component) {
+    const sjekklistepunkt = component?.resourceBindings?.sjekklistepunkt;
+    const sjekklistepunktsvar = component?.resourceBindings?.sjekklistepunktsvar;
+    if (!sjekklistepunkt || !sjekklistepunktsvar) {
+        return null;
+    }
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        resourceBindings: {
+            sjekklistepunkt,
+            sjekklistepunktsvar
+        }
+    });
+    return createCustomElement("custom-group-sjekklistekrav-header-text", htmlAttributes);
+}
+
+/**
  * Renders a custom group element for "sjekklistekrav" (checklist requirements).
  *
  * @param {Object} sjekklistekrav - The checklist requirements data to be rendered.

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -40,6 +40,7 @@ import customGroupRammebetingelserTilknytninger from "./data-components/custom-g
 import customGroupSamsvarAnsvarsomraade from "./data-components/custom-grouplist-samsvar-ansvarsomraade/custom-group-samsvar-ansvarsomraade/index.js";
 import customGroupSamsvarErklaeringer from "./data-components/custom-group-samsvar-erklaeringer/index.js";
 import customGroupSjekklistekrav from "./data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/index.js";
+import customGroupSjekklistekravHeaderText from "./data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav-header-text/index.js";
 import customGroupUtfallSvar from "./data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js";
 import customGroupUtfallSvarType from "./data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/index.js";
 import customGroupVannforsyning from "./data-components/custom-group-vannforsyning/index.js";
@@ -132,6 +133,7 @@ export {
     customGroupSamsvarAnsvarsomraade,
     customGroupSamsvarErklaeringer,
     customGroupSjekklistekrav,
+    customGroupSjekklistekravHeaderText,
     customGroupUtfallSvar,
     customGroupUtfallSvarType,
     customGroupVannforsyning,

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -426,8 +426,20 @@
             "value": "Ansvarlig kontrollerende bekrefter at kontrollen er gjennomført på en forskriftsmessig måte, og at kontrollforetaket er uavhengig av foretakene som er kontrollert."
         },
         {
+            "id": "resource.krav.sjekklistekrav.description",
+            "value": "Søknaden kvalifiserer til automatisk saksbehandling hvis alle kravene er besvart med \"ja\". Dersom ett eller flere av svarene er \"nei\", eller kommunen ikke tilbyr automatisk saksbehandling, vil den bli saksbehandlet manuelt."
+        },
+        {
+            "id": "resource.krav.sjekklistekrav.sjekklistepunkt.title",
+            "value": "Krav til automatisert behandling"
+        },
+        {
+            "id": "resource.krav.sjekklistekrav.sjekklistepunksvar.title",
+            "value": "Svar"
+        },
+        {
             "id": "resource.krav.sjekklistekrav.title",
-            "value": "Svar på vilkår for automatisert behandling"
+            "value": "Svar på krav til automatisert behandling"
         },
         {
             "id": "resource.kravFerdigattest.bekreftelseInnen.title",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -636,9 +636,27 @@
         }
     },
     {
+        "id": "resource.krav.sjekklistekrav.description",
+        "values": {
+            "nb": "Søknaden kvalifiserer til automatisk saksbehandling hvis alle kravene er besvart med \"ja\". Dersom ett eller flere av svarene er \"nei\", eller kommunen ikke tilbyr automatisk saksbehandling, vil den bli saksbehandlet manuelt."
+        }
+    },
+    {
+        "id": "resource.krav.sjekklistekrav.sjekklistepunkt.title",
+        "values": {
+            "nb": "Krav til automatisert behandling"
+        }
+    },
+    {
+        "id": "resource.krav.sjekklistekrav.sjekklistepunksvar.title",
+        "values": {
+            "nb": "Svar"
+        }
+    },
+    {
         "id": "resource.krav.sjekklistekrav.title",
         "values": {
-            "nb": "Svar på vilkår for automatisert behandling"
+            "nb": "Svar på krav til automatisert behandling"
         }
     },
     {

--- a/src/functions/componentHelpers.js
+++ b/src/functions/componentHelpers.js
@@ -38,6 +38,7 @@ import CustomGroupRammebetingelserTilknytninger from "../classes/system-classes/
 import CustomGroupSamsvarAnsvarsomraade from "../classes/system-classes/component-classes/CustomGroupSamsvarAnsvarsomraade.js";
 import CustomGroupSamsvarErklaeringer from "../classes/system-classes/component-classes/CustomGroupSamsvarErklaeringer.js";
 import CustomGroupSjekklistekrav from "../classes/system-classes/component-classes/CustomGroupSjekklistekrav.js";
+import CustomGroupSjekklistekravHeaderText from "../classes/system-classes/component-classes/CustomGroupSjekklistekravHeaderText.js";
 import CustomGroupUtfallSvar from "../classes/system-classes/component-classes/CustomGroupUtfallSvar.js";
 import CustomGroupUtfallSvarType from "../classes/system-classes/component-classes/CustomGroupUtfallSvarType.js";
 import CustomGroupVannforsyning from "../classes/system-classes/component-classes/CustomGroupVannforsyning.js";
@@ -119,6 +120,7 @@ export function getComponentForTagName(tagName) {
         "custom-group-samsvar-ansvarsomraade": CustomGroupSamsvarAnsvarsomraade,
         "custom-group-samsvar-erklaeringer": CustomGroupSamsvarErklaeringer,
         "custom-group-sjekklistekrav": CustomGroupSjekklistekrav,
+        "custom-group-sjekklistekrav-header-text": CustomGroupSjekklistekravHeaderText,
         "custom-group-utfall-svar": CustomGroupUtfallSvar,
         "custom-group-utfall-svar-type": CustomGroupUtfallSvarType,
         "custom-group-vannforsyning": CustomGroupVannforsyning,


### PR DESCRIPTION
Introduces a dedicated header and description support for checklist requirement lists.

This change adds a new custom component `custom-group-sjekklistekrav-header-text` to display structured header information above checklist items. The main `CustomGrouplistSjekklistekrav` component is updated to integrate this new header, support a description field, and refine its resource binding management.

### Changes

- **New Component**: A new custom element, `custom-group-sjekklistekrav-header-text`, and its corresponding class `CustomGroupSjekklistekravHeaderText` have been introduced. This component is responsible for rendering a header row with distinct titles for "sjekklistepunkt" (checklist point) and "sjekklistepunktsvar" (checklist point answer).
- **Header Integration**: The `custom-grouplist-sjekklistekrav` component now dynamically renders an instance of `custom-group-sjekklistekrav-header-text` at the beginning of its list of checklist requirements, provided the necessary resource bindings are present.
- **Description Support**: The `CustomGrouplistSjekklistekrav` class constructor and `resourceValues` now include explicit support for a `description` field, allowing for a general descriptive text to be displayed for the list.
- **Resource Binding Refinement**: Resource bindings within `CustomGrouplistSjekklistekrav` are now more explicitly defined, specifically listing `sjekklistepunkt`, `sjekklistepunktsvar`, `trueText`, `falseText`, and `defaultText`.
- **Styling Adjustment**: A right padding of `10px` has been added to the `custom-field` elements used to render the checklist requirement text within `custom-group-sjekklistekrav`.
- **Component Registration**: The new component class and custom element have been registered in `src/components/index.js` and `src/functions/componentHelpers.js` for system-wide availability.

### Impact

- **Behavioral Changes**: The `custom-grouplist-sjekklistekrav` component will now display a configurable header row with titles for "checklist point" and "answer" at the top of its rendered list if the relevant resource bindings are provided. It also gains the ability to display a general description.
- **Dependencies Affected**: The `custom-grouplist-sjekklistekrav` component now has a direct dependency on the newly introduced `custom-group-sjekklistekrav-header-text` component.
- **Breaking Changes**: No apparent breaking changes; the modifications are additive and extend existing functionality.
- **Performance Implications**: Negligible; involves rendering one additional custom component per `custom-grouplist-sjekklistekrav` instance.
