### PR TITLE
Feature/refactor resources

### DIFF
--- a/src/classes/system-classes/component-classes/CustomDispensasjon.js
+++ b/src/classes/system-classes/component-classes/CustomDispensasjon.js
@@ -131,7 +131,7 @@ export default class CustomDispensasjon extends CustomComponent {
                 emptyFieldText: props?.resourceBindings?.bygningsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             tiltakstyperHeader: {
-                title: props?.resourceBindings?.tiltakstyperHeader?.title || "resource.tiltakstyper.type.header"
+                title: props?.resourceBindings?.tiltakstyperHeader?.title || "resource.tiltakByggeplaner.title"
             },
             tiltakstyperKode: {
                 title: props?.resourceBindings?.tiltakstyperKode?.title || "resource.tiltakstyper.type.kode.title"

--- a/src/classes/system-classes/component-classes/CustomFieldUtfallSvarStatus.js
+++ b/src/classes/system-classes/component-classes/CustomFieldUtfallSvarStatus.js
@@ -122,7 +122,7 @@ export default class CustomFieldUtfallSvarStatus extends CustomComponent {
      */
     getResourceBindings(props) {
         const resourceBindings = {
-            title: props?.resourceBindings?.title || "resource.utfallBesvarelse.utfallSvar.status.title",
+            title: props?.resourceBindings?.title || "resource.status.title",
             erUtfallBesvaresSenere: props?.resourceBindings?.erUtfallBesvaresSenere || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvaresSenere",
             erUtfallBesvart: props?.resourceBindings?.erUtfallBesvart || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvart",
             status: props?.resourceBindings?.status || "resource.utfallBesvarelse.utfallSvar.status"

--- a/src/classes/system-classes/component-classes/CustomFieldUtfallSvarStatus.test.js
+++ b/src/classes/system-classes/component-classes/CustomFieldUtfallSvarStatus.test.js
@@ -176,7 +176,7 @@ describe("CustomFieldUtfallSvarStatus", () => {
         it("should return default resource bindings if none provided", () => {
             const instance = new CustomFieldUtfallSvarStatus({});
             const result = instance.getResourceBindings({});
-            expect(result.utfallSvarStatus.title).toBe("resource.utfallBesvarelse.utfallSvar.status.title");
+            expect(result.utfallSvarStatus.title).toBe("resource.status.title");
             expect(result.utfallSvarStatus.erUtfallBesvaresSenere).toBe("resource.utfallBesvarelse.utfallSvar.erUtfallBesvaresSenere");
             expect(result.utfallSvarStatus.erUtfallBesvart).toBe("resource.utfallBesvarelse.utfallSvar.erUtfallBesvart");
             expect(result.utfallSvarStatus.status).toBe("resource.utfallBesvarelse.utfallSvar.status");

--- a/src/classes/system-classes/component-classes/CustomGjennomfoeringsplan.js
+++ b/src/classes/system-classes/component-classes/CustomGjennomfoeringsplan.js
@@ -144,7 +144,7 @@ export default class CustomGjennomfoeringsplan extends CustomComponent {
                     "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.default",
                 emptyFieldTextAvsluttet:
                     props?.resourceBindings?.ansvarsomraadeStatus?.emptyFieldTextAvsluttet ||
-                    "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.avsluttet"
+                    "resource.emptyFieldText.default"
             },
             ansvarsomraadeStatus: {
                 title: props?.resourceBindings?.ansvarsomraadeStatus?.title || "resource.ansvarsomraadeStatus.title",

--- a/src/classes/system-classes/component-classes/CustomGjenpartNabovarsel.js
+++ b/src/classes/system-classes/component-classes/CustomGjenpartNabovarsel.js
@@ -296,7 +296,7 @@ export default class CustomGjenpartNabovarsel extends CustomComponent {
                 emptyFieldText: props?.resourceBindings?.bestemmelserType?.emptyFieldText || "resource.emptyFieldText.default"
             },
             rowNumber: {
-                title: props?.resourceBindings?.rowNumber?.title || "resource.rowNumberTitle.default"
+                title: props?.resourceBindings?.rowNumber?.title || "resource.nummer.short"
             }
         };
     }

--- a/src/classes/system-classes/component-classes/CustomGroupAvloep.js
+++ b/src/classes/system-classes/component-classes/CustomGroupAvloep.js
@@ -116,7 +116,7 @@ export default class CustomGroupAvloep extends CustomComponent {
                 falseText: props?.resourceBindings?.krysserAvloepAnnensGrunn?.falseText || `resource.falseText.default`
             },
             tilknytningstype: {
-                title: props?.resourceBindings?.tilknytningstype?.title || `resource.rammebetingelser.avloep.tilknytningstype.title`
+                title: props?.resourceBindings?.tilknytningstype?.title || `resource.tilknytning.title`
             },
             skalInstallereVannklosett: {
                 title:

--- a/src/classes/system-classes/component-classes/CustomGroupEttersending.js
+++ b/src/classes/system-classes/component-classes/CustomGroupEttersending.js
@@ -85,7 +85,7 @@ export default class CustomGroupEttersending extends CustomComponent {
     getResourceBindings(props) {
         const resourceBindings = {
             tema: {
-                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.ettersendinger.ettersending.tema.kodebeskrivelse.title"
+                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.tema.title"
             },
             kommentar: {
                 title: props?.resourceBindings?.kommentar?.title || "resource.kommentar.title"

--- a/src/classes/system-classes/component-classes/CustomGroupEttersending.js
+++ b/src/classes/system-classes/component-classes/CustomGroupEttersending.js
@@ -91,7 +91,7 @@ export default class CustomGroupEttersending extends CustomComponent {
                 title: props?.resourceBindings?.kommentar?.title || "resource.kommentar.title"
             },
             vedleggsliste: {
-                title: props?.resourceBindings?.vedleggsliste?.vedlegg?.title || "resource.ettersendinger.ettersending.vedleggsliste.vedlegg.title"
+                title: props?.resourceBindings?.vedleggsliste?.vedlegg?.title || "resource.vedlegg.title"
             },
             ettersending: {}
         };

--- a/src/classes/system-classes/component-classes/CustomGroupRammebetingelserTilknytninger.js
+++ b/src/classes/system-classes/component-classes/CustomGroupRammebetingelserTilknytninger.js
@@ -133,7 +133,7 @@ export default class CustomGroupRammebetingelserTilknytninger extends CustomComp
                 falseText: props?.resourceBindings?.avloep?.krysserAvloepAnnensGrunn?.falseText || "resource.falseText.default"
             },
             avloepTilknytningstype: {
-                title: props?.resourceBindings?.avloep?.tilknytningstype?.title || "resource.rammebetingelser.avloep.tilknytningstype.title"
+                title: props?.resourceBindings?.avloep?.tilknytningstype?.title || "resource.tilknytning.title"
             },
             avloepSkalInstallereVannklosett: {
                 title:
@@ -190,7 +190,7 @@ export default class CustomGroupRammebetingelserTilknytninger extends CustomComp
             vannforsyningTilknytningstype: {
                 title:
                     props?.resourceBindings?.vannforsyning?.tilknytningstype?.title ||
-                    "resource.rammebetingelser.vannforsyning.tilknytningstype.title"
+                    "resource.tilknytning.title"
             }
         };
         if (props?.hideTitle !== true && props?.hideTitle !== "true") {

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
@@ -101,7 +101,7 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
     getResourceBindings(props) {
         const resourceBindings = {
             utfallSvarStatus: {
-                title: props?.resourceBindings?.status?.title || "resource.utfallBesvarelse.utfallSvar.status.title",
+                title: props?.resourceBindings?.status?.title || "resource.status.title",
                 status: props?.resourceBindings?.status?.status || "resource.utfallBesvarelse.utfallSvar.status",
                 erUtfallBesvaresSenere:
                     props?.resourceBindings?.erUtfallBesvaresSenere || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvaresSenere",

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvar.js
@@ -108,7 +108,7 @@ export default class CustomGroupUtfallSvar extends CustomComponent {
                 erUtfallBesvart: props?.resourceBindings?.erUtfallBesvart || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvart"
             },
             tema: {
-                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title"
+                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.tema.title"
             },
             kommentar: {
                 title: props?.resourceBindings?.kommentar?.title || "resource.utfallBesvarelse.utfallSvar.kommentar.title"

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.js
@@ -105,7 +105,7 @@ export default class CustomGroupUtfallSvarType extends CustomComponent {
                 title: props?.resourceBindings?.tema?.title || `resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title`
             },
             utfallSvarStatus: {
-                title: props?.resourceBindings?.utfallSvarStatus?.title || `resource.utfallBesvarelse.utfallSvar.status.title`
+                title: props?.resourceBindings?.utfallSvarStatus?.title || `resource.status.title`
             },
             vedleggsliste: {
                 title: props?.resourceBindings?.vedleggsliste?.title || `resource.utfallBesvarelse.utfallSvar.vedleggsliste.vedlegg.title`

--- a/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.js
+++ b/src/classes/system-classes/component-classes/CustomGroupUtfallSvarType.js
@@ -102,7 +102,7 @@ export default class CustomGroupUtfallSvarType extends CustomComponent {
                 title: props?.resourceBindings?.kommentar?.title || `resource.utfallBesvarelse.utfallSvar.kommentar.title`
             },
             tema: {
-                title: props?.resourceBindings?.tema?.title || `resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title`
+                title: props?.resourceBindings?.tema?.title || `resource.tema.title`
             },
             utfallSvarStatus: {
                 title: props?.resourceBindings?.utfallSvarStatus?.title || `resource.status.title`

--- a/src/classes/system-classes/component-classes/CustomGroupVannforsyning.js
+++ b/src/classes/system-classes/component-classes/CustomGroupVannforsyning.js
@@ -106,7 +106,7 @@ export default class CustomGroupVannforsyning extends CustomComponent {
                 falseText: props?.resourceBindings?.krysserVannforsyningAnnensGrunn?.falseText || `resource.falseText.default`
             },
             tilknytningstype: {
-                title: props?.resourceBindings?.tilknytningstype?.title || `resource.rammebetingelser.vannforsyning.tilknytningstype.title`
+                title: props?.resourceBindings?.tilknytningstype?.title || `resource.tilknytning.title`
             }
         };
         if (props?.hideTitle !== true && props?.hideTitle !== "true") {

--- a/src/classes/system-classes/component-classes/CustomGrouplistAnsvarsomraadeType.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistAnsvarsomraadeType.js
@@ -120,7 +120,7 @@ export default class CustomGrouplistAnsvarsomraadeType extends CustomComponent {
                     "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.default",
                 emptyFieldTextAvsluttet:
                     props?.resourceBindings?.ansvarsomraadeStatus?.emptyFieldTextAvsluttet ||
-                    "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.avsluttet"
+                    "resource.emptyFieldText.default"
             },
             ansvarsomraadeStatus: {
                 title: props?.resourceBindings?.ansvarsomraadeStatus?.title || "resource.ansvarsomraadeStatus.title",

--- a/src/classes/system-classes/component-classes/CustomGrouplistEttersending.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistEttersending.js
@@ -102,7 +102,7 @@ export default class CustomGrouplistEttersending extends CustomComponent {
     getResourceBindings(props) {
         const resourceBindings = {
             tema: {
-                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.ettersendinger.ettersending.tema.kodebeskrivelse.title"
+                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.tema.title"
             },
             kommentar: {
                 title: props?.resourceBindings?.kommentar?.title || "resource.kommentar.title"

--- a/src/classes/system-classes/component-classes/CustomGrouplistEttersending.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistEttersending.js
@@ -108,7 +108,7 @@ export default class CustomGrouplistEttersending extends CustomComponent {
                 title: props?.resourceBindings?.kommentar?.title || "resource.kommentar.title"
             },
             vedleggsliste: {
-                title: props?.resourceBindings?.vedleggsliste?.vedlegg?.title || "resource.ettersendinger.ettersending.vedleggsliste.vedlegg.title"
+                title: props?.resourceBindings?.vedleggsliste?.vedlegg?.title || "resource.vedlegg.title"
             },
             ettersendinger: {}
         };

--- a/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.js
@@ -97,7 +97,7 @@ export default class CustomGrouplistUtfallSvar extends CustomComponent {
     getResourceBindings(props) {
         const resourceBindings = {
             utfallSvarStatus: {
-                title: props?.resourceBindings?.status?.title || "resource.utfallBesvarelse.utfallSvar.status.title",
+                title: props?.resourceBindings?.status?.title || "resource.status.title",
                 status: props?.resourceBindings?.status?.status || "resource.utfallBesvarelse.utfallSvar.status",
                 erUtfallBesvaresSenere:
                     props?.resourceBindings?.erUtfallBesvaresSenere || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvaresSenere",

--- a/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvar.js
@@ -104,7 +104,7 @@ export default class CustomGrouplistUtfallSvar extends CustomComponent {
                 erUtfallBesvart: props?.resourceBindings?.erUtfallBesvart || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvart"
             },
             tema: {
-                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title"
+                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.tema.title"
             },
             kommentar: {
                 title: props?.resourceBindings?.kommentar?.title || "resource.utfallBesvarelse.utfallSvar.kommentar.title"

--- a/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvarType.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvarType.js
@@ -119,7 +119,7 @@ export default class CustomGrouplistUtfallSvarType extends CustomComponent {
     getResourceBindings(props) {
         const resourceBindings = {
             utfallSvarStatus: {
-                title: props?.resourceBindings?.status?.title || "resource.utfallBesvarelse.utfallSvar.status.title",
+                title: props?.resourceBindings?.status?.title || "resource.status.title",
                 status: props?.resourceBindings?.status?.status || "resource.utfallBesvarelse.utfallSvar.status",
                 erUtfallBesvaresSenere:
                     props?.resourceBindings?.erUtfallBesvaresSenere || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvaresSenere",

--- a/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvarType.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistUtfallSvarType.js
@@ -126,7 +126,7 @@ export default class CustomGrouplistUtfallSvarType extends CustomComponent {
                 erUtfallBesvart: props?.resourceBindings?.erUtfallBesvart || "resource.utfallBesvarelse.utfallSvar.erUtfallBesvart"
             },
             tema: {
-                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title"
+                title: props?.resourceBindings?.tema?.kodebeskrivelse?.title || "resource.tema.title"
             },
             kommentar: {
                 title: props?.resourceBindings?.kommentar?.title || "resource.utfallBesvarelse.utfallSvar.kommentar.title"

--- a/src/classes/system-classes/component-classes/CustomTableAnsvarsomraade.js
+++ b/src/classes/system-classes/component-classes/CustomTableAnsvarsomraade.js
@@ -122,7 +122,7 @@ export default class CustomTableAnsvarsomraade extends CustomComponent {
                     "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.default",
                 emptyFieldTextAvsluttet:
                     props?.resourceBindings?.ansvarsomraadeStatus?.emptyFieldTextAvsluttet ||
-                    "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.avsluttet"
+                    "resource.emptyFieldText.default"
             },
             ansvarsomraadeStatus: {
                 title: props?.resourceBindings?.ansvarsomraadeStatus?.title || "resource.ansvarsomraadeStatus.title",

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -266,10 +266,6 @@
             "value": "Ettersending"
         },
         {
-            "id": "resource.ettersendinger.ettersending.vedleggsliste.vedlegg.title",
-            "value": "Vedlegg"
-        },
-        {
             "id": "resource.fakturareferanse.title",
             "value": "Fakturareferanse"
         },
@@ -1140,6 +1136,10 @@
         {
             "id": "resource.varsling.vurderingAvMerknader.title",
             "value": "Søkers vurdering av merknadene"
+        },
+        {
+            "id": "resource.vedlegg.title",
+            "value": "Vedlegg"
         },
         {
             "id": "resource.versjon.title",

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -518,6 +518,10 @@
             "value": "Navn"
         },
         {
+            "id": "resource.nummer.short",
+            "value": "Nr."
+        },
+        {
             "id": "resource.operator.equals",
             "value": "="
         },
@@ -1012,6 +1016,14 @@
         {
             "id": "resource.stedfesting.vertikalnivaa.title",
             "value": "Vertikalnivå"
+        },
+        {
+            "id": "resource.tema.title",
+            "value": "Tema"
+        },
+        {
+            "id": "resource.tilknytning.title",
+            "value": "Tilknytning"
         },
         {
             "id": "resource.tilstrekkeligSikkerhet.title",

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -1030,6 +1030,10 @@
             "value": "Har tiltaket tilstrekkelig sikkerhetsnivå til å tas i bruk?"
         },
         {
+            "id": "resource.tiltakByggeplaner.title",
+            "value": "Tiltak/ byggeplaner"
+        },
+        {
             "id": "resource.tiltakshaver.fakturamottaker.title",
             "value": "Fakturaadresse for tiltakshaver"
         },

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -262,14 +262,6 @@
             "value": "Erklæring"
         },
         {
-            "id": "resource.ettersendinger.ettersending.kommentar.title",
-            "value": "Kommentar"
-        },
-        {
-            "id": "resource.ettersendinger.ettersending.tema.kodebeskrivelse.title",
-            "value": "Tema"
-        },
-        {
             "id": "resource.ettersendinger.ettersending.title",
             "value": "Ettersending"
         },
@@ -610,10 +602,6 @@
             "value": "Grad av utnytting i henhold til gjeldende plan"
         },
         {
-            "id": "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.avsluttet",
-            "value": "-"
-        },
-        {
             "id": "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.default",
             "value": "Planlagt"
         },
@@ -712,10 +700,6 @@
         {
             "id": "resource.rammebetingelser.avloep.skalInstallereVannklosett.title",
             "value": "Skal det installeres vannklosett?"
-        },
-        {
-            "id": "resource.rammebetingelser.avloep.tilknytningstype.title",
-            "value": "Tilknytning"
         },
         {
             "id": "resource.rammebetingelser.avloep.title",
@@ -832,10 +816,6 @@
         {
             "id": "resource.rammebetingelser.vannforsyning.krysserVannforsyningAnnensGrunn.title",
             "value": "Krysser vanntilførsel annens grunn?"
-        },
-        {
-            "id": "resource.rammebetingelser.vannforsyning.tilknytningstype.title",
-            "value": "Tilknytning"
         },
         {
             "id": "resource.rammebetingelser.vannforsyning.title",
@@ -1050,10 +1030,6 @@
             "value": "Tiltaksklasse"
         },
         {
-            "id": "resource.tiltakstyper.type.header",
-            "value": "Tiltak/ byggeplaner"
-        },
-        {
             "id": "resource.tiltakstyper.type.kode.title",
             "value": "Tiltakstyper i søknad om dispensasjon"
         },
@@ -1084,14 +1060,6 @@
         {
             "id": "resource.utfallBesvarelse.utfallSvar.status",
             "value": "Besvares nå"
-        },
-        {
-            "id": "resource.utfallBesvarelse.utfallSvar.status.title",
-            "value": "Status"
-        },
-        {
-            "id": "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title",
-            "value": "Tema"
         },
         {
             "id": "resource.utfallBesvarelse.utfallSvar.title",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -177,7 +177,8 @@
         "id": "resource.delsoeknader.delsoeknad.delsoeknadsnummer.title",
         "values": {
             "nb": "Nr."
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.delsoeknader.delsoeknad.kommentar.title",
@@ -244,7 +245,8 @@
         "id": "resource.dispensasjonOversikt.dispensasjon.dispensasjonTittel.title",
         "values": {
             "nb": "Emne"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.dispensasjonOversikt.header",
@@ -402,7 +404,8 @@
         "id": "resource.ettersendinger.ettersending.tema.kodebeskrivelse.title",
         "values": {
             "nb": "Tema"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.ettersendinger.ettersending.title",
@@ -504,7 +507,8 @@
         "id": "resource.generelleVilkaar.norskSvenskDansk.header",
         "values": {
             "nb": "Erklæring"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.generelleVilkaar.norskSvenskDansk.true.title",
@@ -777,6 +781,12 @@
         }
     },
     {
+        "id": "resource.nummer.short",
+        "values": {
+            "nb": "Nr."
+        }
+    },
+    {
         "id": "resource.operator.equals",
         "values": {
             "nb": "="
@@ -914,7 +924,8 @@
         "id": "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.avsluttet",
         "values": {
             "nb": "-"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.default",
@@ -1070,7 +1081,8 @@
         "id": "resource.rammebetingelser.avloep.tilknytningstype.title",
         "values": {
             "nb": "Tilknytning"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.rammebetingelser.avloep.title",
@@ -1250,7 +1262,8 @@
         "id": "resource.rammebetingelser.vannforsyning.tilknytningstype.title",
         "values": {
             "nb": "Tilknytning"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.rammebetingelser.vannforsyning.title",
@@ -1310,7 +1323,8 @@
         "id": "resource.rowNumberTitle.default",
         "values": {
             "nb": "Nr."
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.samsvarErklaeringTekst.title",
@@ -1525,6 +1539,18 @@
         }
     },
     {
+        "id": "resource.tema.title",
+        "values": {
+            "nb": "Tema"
+        }
+    },
+    {
+        "id": "resource.tilknytning.title",
+        "values": {
+            "nb": "Tilknytning"
+        }
+    },
+    {
         "id": "resource.tilstrekkeligSikkerhet.title",
         "values": {
             "nb": "Har tiltaket tilstrekkelig sikkerhetsnivå til å tas i bruk?"
@@ -1613,13 +1639,15 @@
         "id": "resource.utfallBesvarelse.utfallSvar.status.title",
         "values": {
             "nb": "Status"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title",
         "values": {
             "nb": "Tema"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.utfallBesvarelse.utfallSvar.title",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -394,20 +394,6 @@
         }
     },
     {
-        "id": "resource.ettersendinger.ettersending.kommentar.title",
-        "values": {
-            "nb": "Kommentar"
-        },
-        "deprecated": true
-    },
-    {
-        "id": "resource.ettersendinger.ettersending.tema.kodebeskrivelse.title",
-        "values": {
-            "nb": "Tema"
-        },
-        "deprecated": true
-    },
-    {
         "id": "resource.ettersendinger.ettersending.title",
         "values": {
             "nb": "Ettersending"
@@ -921,13 +907,6 @@
         }
     },
     {
-        "id": "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.avsluttet",
-        "values": {
-            "nb": "-"
-        },
-        "deprecated": true
-    },
-    {
         "id": "resource.planlagteSamsvarKontrollErklaeringer.emptyFieldText.default",
         "values": {
             "nb": "Planlagt"
@@ -1076,13 +1055,6 @@
         "values": {
             "nb": "Skal det installeres vannklosett?"
         }
-    },
-    {
-        "id": "resource.rammebetingelser.avloep.tilknytningstype.title",
-        "values": {
-            "nb": "Tilknytning"
-        },
-        "deprecated": true
     },
     {
         "id": "resource.rammebetingelser.avloep.title",
@@ -1257,13 +1229,6 @@
         "values": {
             "nb": "Krysser vanntilførsel annens grunn?"
         }
-    },
-    {
-        "id": "resource.rammebetingelser.vannforsyning.tilknytningstype.title",
-        "values": {
-            "nb": "Tilknytning"
-        },
-        "deprecated": true
     },
     {
         "id": "resource.rammebetingelser.vannforsyning.title",
@@ -1588,13 +1553,6 @@
         }
     },
     {
-        "id": "resource.tiltakstyper.type.header",
-        "values": {
-            "nb": "Tiltak/ byggeplaner"
-        },
-        "deprecated": true
-    },
-    {
         "id": "resource.tiltakstyper.type.kode.title",
         "values": {
             "nb": "Tiltakstyper i søknad om dispensasjon"
@@ -1642,20 +1600,6 @@
         "values": {
             "nb": "Besvares nå"
         }
-    },
-    {
-        "id": "resource.utfallBesvarelse.utfallSvar.status.title",
-        "values": {
-            "nb": "Status"
-        },
-        "deprecated": true
-    },
-    {
-        "id": "resource.utfallBesvarelse.utfallSvar.tema.kodebeskrivelse.title",
-        "values": {
-            "nb": "Tema"
-        },
-        "deprecated": true
     },
     {
         "id": "resource.utfallBesvarelse.utfallSvar.title",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -400,12 +400,6 @@
         }
     },
     {
-        "id": "resource.ettersendinger.ettersending.vedleggsliste.vedlegg.title",
-        "values": {
-            "nb": "Vedlegg"
-        }
-    },
-    {
         "id": "resource.fakturareferanse.title",
         "values": {
             "nb": "Fakturareferanse"
@@ -1721,6 +1715,12 @@
         "id": "resource.varsling.vurderingAvMerknader.title",
         "values": {
             "nb": "Søkers vurdering av merknadene"
+        }
+    },
+    {
+        "id": "resource.vedlegg.title",
+        "values": {
+            "nb": "Vedlegg"
         }
     },
     {

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -1451,7 +1451,8 @@
         "id": "resource.soeknadGjelder.bruk.header",
         "values": {
             "nb": "Tiltak/ byggeplaner"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.soeknadGjelder.bruk.naeringsgruppe.title",
@@ -1557,6 +1558,12 @@
         }
     },
     {
+        "id": "resource.tiltakByggeplaner.title",
+        "values": {
+            "nb": "Tiltak/ byggeplaner"
+        }
+    },
+    {
         "id": "resource.tiltakshaver.fakturamottaker.title",
         "values": {
             "nb": "Fakturaadresse for tiltakshaver"
@@ -1584,7 +1591,8 @@
         "id": "resource.tiltakstyper.type.header",
         "values": {
             "nb": "Tiltak/ byggeplaner"
-        }
+        },
+        "deprecated": true
     },
     {
         "id": "resource.tiltakstyper.type.kode.title",


### PR DESCRIPTION
Standardizes and refactors resource keys across multiple components and resource files.

This pull request consolidates numerous specific resource keys into more generic, reusable ones for common UI labels like "Tema", "Status", "Tilknytning", and "Vedlegg". It also includes deprecation or removal of legacy resource entries, streamlining resource management.

### Changes

- **Resource Key Renaming and Consolidation**: Updated `resourceBindings` in 16 component classes to use new, standardized resource keys. Examples include `resource.tiltakstyper.type.header` to `resource.tiltakByggeplaner.title`, `resource.utfallBesvarelse.utfallSvar.status.title` to `resource.status.title`, and `resource.ettersendinger.ettersending.tema.kodebeskrivelse.title` to `resource.tema.title`.
- **Resource File Updates**:
  - `resource.nb.json`: Removed many specific, deeply nested resource entries and introduced new, more generic keys (`resource.nummer.short`, `resource.tema.title`, `resource.tilknytning.title`, `resource.tiltakByggeplaner.title`, `resource.vedlegg.title`, `resource.status.title`).
  - `resources.json`: Mirroring `resource.nb.json`, old entries were removed, new generic ones added, and several legacy resource IDs were explicitly marked with `"deprecated": true`.
- **Test Updates**: `CustomFieldUtfallSvarStatus.test.js` was updated to reflect the new default resource binding for status titles.

### Impact

- **Behavioral changes**: The display text for various UI elements will now be resolved using the updated, standardized resource keys, leading to consistent terminology across the application. Users will observe no functional change beyond potentially different, standardized labels for certain fields.
- **Dependencies affected**: All `CustomComponent` derivatives updated in the diff are affected by the new resource key structure. Any other components or parts of the application directly referencing the deprecated or removed resource keys would need to be updated.
- **Breaking changes, if any**: Components not included in this diff that might still reference the deprecated or removed resource keys (`resource.ettersendinger.ettersending.kommentar.title`, `resource.tiltakstyper.type.header`, etc.) would experience undefined or incorrect text resolution. However, the diff indicates a comprehensive migration within the affected files.
- **Performance implications, if apparent**: No significant performance implications are expected from these changes, as they primarily involve string lookup key modifications.
