### PR TITLE
Feature/remove part type property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -162,7 +162,6 @@
         "Overvann",
         "paragrafnummer",
         "parkeringsareal",
-        "parttype",
         "Planbestemmelse",
         "Planbestemmelser",
         "planen",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     },
     "packageManager": "yarn@4.10.3",
     "dependencies": {
-        "@arkitektum/altinn-studio-custom-components-utils": "^1.4.3"
+        "@arkitektum/altinn-studio-custom-components-utils": "^1.4.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "html-webpack-plugin": "^5.6.7",
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
-        "jsdom": "^29.1.0",
+        "jsdom": "^29.1.1",
         "mini-css-extract-plugin": "^2.10.2",
         "prettier": "3.8.3",
         "style-loader": "^4.0.0",

--- a/src/classes/system-classes/component-classes/CustomDispensasjon.js
+++ b/src/classes/system-classes/component-classes/CustomDispensasjon.js
@@ -156,7 +156,7 @@ export default class CustomDispensasjon extends CustomComponent {
             },
 
             tiltakshaverKontaktperson: {
-                title: props?.resourceBindings?.tiltakshaverKontaktperson?.title || "resource.tiltakshaver.kontaktperson.title"
+                title: props?.resourceBindings?.tiltakshaverKontaktperson?.title || "resource.kontaktpersonForTiltakshaver.title"
             },
             tiltakshaverKontaktpersonNavn: {
                 title: props?.resourceBindings?.tiltakshaverKontaktpersonNavn?.title || "resource.navn.title",

--- a/src/classes/system-classes/component-classes/CustomGjennomfoeringsplan.js
+++ b/src/classes/system-classes/component-classes/CustomGjennomfoeringsplan.js
@@ -119,7 +119,7 @@ export default class CustomGjennomfoeringsplan extends CustomComponent {
                 emptyFieldText: props?.resourceBindings?.ansvarsomraade?.emptyFieldText || "resource.emptyFieldText.default"
             },
             ansvarligSoeker: {
-                title: props?.resourceBindings?.ansvarligSoeker?.title || "resource.ansvarligSoeker.title"
+                title: props?.resourceBindings?.ansvarligSoeker?.title || "resource.soeker.title"
             },
             ansvarligSoekerNavn: {
                 title: props?.resourceBindings?.ansvarligSoekerNavn?.title || "resource.navn.title",

--- a/src/classes/system-classes/component-classes/CustomGjenpartNabovarsel.js
+++ b/src/classes/system-classes/component-classes/CustomGjenpartNabovarsel.js
@@ -232,7 +232,7 @@ export default class CustomGjenpartNabovarsel extends CustomComponent {
                     props?.resourceBindings?.eiendomMatrikkelinformasjonBygningsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             eier: {
-                title: props?.resourceBindings?.eier?.title || "resource.eier.title"
+                title: props?.resourceBindings?.eier?.title || "resource.eierFesterAvNaboeiendom.title"
             },
             eierNavn: {
                 title: props?.resourceBindings?.eierNavn?.title || "resource.navn.title",

--- a/src/classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.js
@@ -123,7 +123,7 @@ export default class CustomGroupNaboGjenboerEiendom extends CustomComponent {
                 emptyFieldText: props?.resourceBindings?.bygningsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             eier: {
-                title: props?.resourceBindings?.eier?.title || "resource.eier.title"
+                title: props?.resourceBindings?.eier?.title || "resource.eierFesterAvNaboeiendom.title"
             },
             eierNavn: {
                 title: props?.resourceBindings?.eierNavn?.title || "resource.navn.title",

--- a/src/classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.test.js
+++ b/src/classes/system-classes/component-classes/CustomGroupNaboGjenboerEiendom.test.js
@@ -84,7 +84,7 @@ describe("CustomGroupNaboGjenboerEiendom", () => {
         const instance = new CustomGroupNaboGjenboerEiendom({});
         const bindings = instance.getResourceBindings({});
         expect(bindings.eiendomMatrikkelinformasjon.title).toBe("resource.naboGjenboer.eiendommer.eiendom.matrikkelinformasjon.title");
-        expect(bindings.eier.title).toBe("resource.eier.title");
+        expect(bindings.eier.title).toBe("resource.eierFesterAvNaboeiendom.title");
         expect(bindings.naboGjenboerEiendom.emptyFieldText).toBe("resource.emptyFieldText.default");
     });
 

--- a/src/classes/system-classes/component-classes/CustomGrouplistNaboGjenboerEiendom.js
+++ b/src/classes/system-classes/component-classes/CustomGrouplistNaboGjenboerEiendom.js
@@ -165,7 +165,7 @@ export default class CustomGrouplistNaboGjenboerEiendom extends CustomComponent 
                     props?.resourceBindings?.eiendomMatrikkelinformasjonBygningsnummer?.emptyFieldText || "resource.emptyFieldText.default"
             },
             eier: {
-                title: props?.resourceBindings?.eier?.title || "resource.eier.title"
+                title: props?.resourceBindings?.eier?.title || "resource.eierFesterAvNaboeiendom.title"
             },
             eierNavn: {
                 title: props?.resourceBindings?.eierNavn?.title || "resource.navn.title",

--- a/src/classes/system-classes/component-classes/CustomTablePart.js
+++ b/src/classes/system-classes/component-classes/CustomTablePart.js
@@ -18,7 +18,6 @@ import { getComponentDataValue } from "../../../functions/helpers.js";
  *
  * @class
  * @param {Object} props - The properties for the component.
- * @param {string} [props.partType] - The type of part, used for resource key generation.
  * @param {Object} [props.resourceBindings] - Optional custom resource bindings for fields.
  * @param {Object} [props.formData] - The form data object.
  */
@@ -32,25 +31,12 @@ export default class CustomTablePart extends CustomComponent {
         const validationMessages = this.getValidationMessages(resourceBindings);
 
         this.isEmpty = isEmpty;
-        this.partType = props?.partType;
         this.validationMessages = validationMessages;
         this.hasValidationMessages = hasValidationMessages(validationMessages);
         this.resourceBindings = resourceBindings;
         this.resourceValues = {
             data: isEmpty ? getTextResourceFromResourceBinding(props?.resourceBindings?.emptyFieldText) : data
         };
-    }
-
-    /**
-     * Retrieves the part type from the given element's "parttype" attribute.
-     * If the attribute is not present, returns the default value "tiltakshaver".
-     *
-     * @param {Element} element - The DOM element from which to retrieve the "parttype" attribute.
-     * @returns {string} The value of the "parttype" attribute, or "tiltakshaver" if not set.
-     */
-    getPartTypeFromElementAttributes(element) {
-        const partType = element.getAttribute("parttype");
-        return partType || "tiltakshaver";
     }
 
     /**
@@ -139,7 +125,6 @@ export default class CustomTablePart extends CustomComponent {
      * Generates text resource bindings for a custom table part component.
      *
      * @param {Object} props - The properties for the component.
-     * @param {string} [props.partType="tiltakshaver"] - The type of part, used for resource key generation.
      * @param {Object} [props.resourceBindings] - Optional custom resource bindings for fields.
      * @param {Object} [props.resourceBindings.navn] - Resource bindings for the "navn" field.
      * @param {string} [props.resourceBindings.navn.title] - Custom title for the "navn" field.
@@ -154,7 +139,6 @@ export default class CustomTablePart extends CustomComponent {
      * @returns {Object} Resource bindings object for use in the component.
      */
     getResourceBindings(props) {
-        const partType = props?.partType || "tiltakshaver";
         const resourceBindings = {
             navn: {
                 title: props?.resourceBindings?.navn?.title || `resource.navn.title`,
@@ -171,7 +155,7 @@ export default class CustomTablePart extends CustomComponent {
         };
         if (props?.hideTitle !== true && props?.hideTitle !== "true") {
             resourceBindings.part = {
-                title: props?.resourceBindings?.title || `resource.${partType}.title`
+                title: props?.resourceBindings?.title || `resource.tiltakshaver.title`
             };
         }
         if (props?.hideIfEmpty !== true && props?.hideIfEmpty !== "true") {

--- a/src/classes/system-classes/component-classes/CustomTablePart.test.js
+++ b/src/classes/system-classes/component-classes/CustomTablePart.test.js
@@ -54,20 +54,6 @@ describe("CustomTablePart", () => {
         });
     });
 
-    describe("getPartTypeFromElementAttributes", () => {
-        it("should return parttype attribute if present", () => {
-            const element = { getAttribute: jest.fn().mockReturnValue("customType") };
-            const instance = new CustomTablePart({});
-            expect(instance.getPartTypeFromElementAttributes(element)).toBe("customType");
-        });
-
-        it("should return default if parttype attribute is not present", () => {
-            const element = { getAttribute: jest.fn().mockReturnValue(null) };
-            const instance = new CustomTablePart({});
-            expect(instance.getPartTypeFromElementAttributes(element)).toBe("tiltakshaver");
-        });
-    });
-
     describe("getValueFromFormData", () => {
         it("should return undefined if hasValue returns false", () => {
             getComponentDataValue.mockReturnValue(undefined);
@@ -216,7 +202,6 @@ describe("CustomTablePart", () => {
 
         it("should use custom resource bindings if provided", () => {
             const props = {
-                partType: "custom",
                 resourceBindings: {
                     navn: { title: "Custom Navn" },
                     telefonnummer: { title: "Custom Tel" },

--- a/src/components/data-components/custom-grouplist-nabo-gjenboer-eiendom/custom-group-nabo-gjenboer-eiendom/renderers.js
+++ b/src/components/data-components/custom-grouplist-nabo-gjenboer-eiendom/custom-group-nabo-gjenboer-eiendom/renderers.js
@@ -52,7 +52,6 @@ export function renderEierPartElement(component) {
         hideIfEmpty: true,
         hideTitle: false,
         size: component?.size || "h4",
-        partType: "eier",
         resourceBindings: {
             title: component?.resourceBindings?.eier?.title
         },

--- a/src/components/layout-components/dispensasjon/renderers.js
+++ b/src/components/layout-components/dispensasjon/renderers.js
@@ -221,7 +221,6 @@ export function renderTiltakshaver(component) {
     const data = component?.resourceValues?.data;
     const htmlAttributes = new CustomElementHtmlAttributes({
         isChildComponent: true,
-        partType: "tiltakshaver",
         hideIfEmpty: true,
         size: "h2",
         resourceBindings: {
@@ -286,7 +285,6 @@ export function renderTiltakshaverKontaktperson(component) {
     const data = component?.resourceValues?.data;
     const htmlAttributes = new CustomElementHtmlAttributes({
         isChildComponent: true,
-        partType: "tiltakshaver.kontaktperson",
         hideIfEmpty: true,
         size: "h2",
         resourceBindings: {

--- a/src/components/layout-components/gjennomfoeringsplan/renderers.js
+++ b/src/components/layout-components/gjennomfoeringsplan/renderers.js
@@ -221,7 +221,6 @@ export function renderAnsvarligSoeker(component) {
         isChildComponent: true,
         hideIfEmpty: true,
         size: "h3",
-        partType: "ansvarligSoeker",
         resourceBindings: {
             title: component.resourceBindings?.ansvarligSoeker?.title,
             navn: {

--- a/src/components/layout-components/gjenpart-nabovarsel/renderers.js
+++ b/src/components/layout-components/gjenpart-nabovarsel/renderers.js
@@ -481,7 +481,6 @@ export function renderKontaktpersonForNabovarseletElement(component) {
         isChildComponent: true,
         hideIfEmpty: true,
         size: "h2",
-        partType: "kontaktpersonForNabovarselet",
         resourceBindings: {
             title: component.resourceBindings?.kontaktpersonForNabovarselet?.title
         },

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -466,6 +466,10 @@
             "value": "Kontaktperson for nabovarselet"
         },
         {
+            "id": "resource.kontaktpersonForSoeker.title",
+            "value": "Kontaktperson for søker"
+        },
+        {
             "id": "resource.kontaktpersonForTiltakshaver.title",
             "value": "Kontaktperson for tiltakshaver"
         },

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -466,6 +466,10 @@
             "value": "Kontaktperson for nabovarselet"
         },
         {
+            "id": "resource.kontaktpersonForTiltakshaver.title",
+            "value": "Kontaktperson for tiltakshaver"
+        },
+        {
             "id": "resource.kontrollErklaeringTekst.title",
             "value": "Vi er kjent med reglene om straff og sanksjoner i plan- og bygningslovens kapittel 32, og at det kan medføre reaksjoner dersom vi oppgir uriktige opplysninger."
         },

--- a/src/data/resource.nb.json
+++ b/src/data/resource.nb.json
@@ -234,7 +234,7 @@
             "value": "Eiendom/byggested"
         },
         {
-            "id": "resource.eier.title",
+            "id": "resource.eierFesterAvNaboeiendom.title",
             "value": "Eier/fester av naboeiendom"
         },
         {

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -707,6 +707,12 @@
         }
     },
     {
+        "id": "resource.kontaktpersonForTiltakshaver.title",
+        "values": {
+            "nb": "Kontaktperson for tiltakshaver"
+        }
+    },
+    {
         "id": "resource.kontrollErklaeringTekst.title",
         "values": {
             "nb": "Vi er kjent med reglene om straff og sanksjoner i plan- og bygningslovens kapittel 32, og at det kan medføre reaksjoner dersom vi oppgir uriktige opplysninger."
@@ -1649,7 +1655,8 @@
         "id": "resource.tiltakshaver.kontaktperson.title",
         "values": {
             "nb": "Kontaktperson for tiltakshaver"
-        }
+        },
+        "replacedWithId": "resource.kontaktpersonForTiltakshaver.title"
     },
     {
         "id": "resource.tiltakshaver.title",

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -355,7 +355,7 @@
         }
     },
     {
-        "id": "resource.eier.title",
+        "id": "resource.eierFesterAvNaboeiendom.title",
         "values": {
             "nb": "Eier/fester av naboeiendom"
         }

--- a/src/data/resources.json
+++ b/src/data/resources.json
@@ -21,7 +21,8 @@
         "id": "resource.ansvarligSoeker.kontaktperson.title",
         "values": {
             "nb": "Kontaktperson for søker"
-        }
+        },
+        "replacedWithId": "resource.kontaktpersonForSoeker.title"
     },
     {
         "id": "resource.ansvarligSoeker.title",
@@ -704,6 +705,12 @@
         "id": "resource.kontaktpersonForNabovarselet.title",
         "values": {
             "nb": "Kontaktperson for nabovarselet"
+        }
+    },
+    {
+        "id": "resource.kontaktpersonForSoeker.title",
+        "values": {
+            "nb": "Kontaktperson for søker"
         }
     },
     {

--- a/src/functions/htmlElementHelpers.js
+++ b/src/functions/htmlElementHelpers.js
@@ -28,7 +28,6 @@ import { hasValue, isValidHeaderSize } from "@arkitektum/altinn-studio-custom-co
  *   @property {boolean} showRowNumbers - Whether to show row numbers.
  *   @property {Object} resourceBindings - Text resource bindings for the element.
  *   @property {Object} resourceValues - Resource values for the element.
- *   @property {string} partType - The type of part defined for the element.
  *   @property {boolean} enableLinks - Whether to enable links in the field value.
  *   @property {string} sortKey - The sort key associated with the element.
  *   @property {string} endSymbol - The end symbol for the element.
@@ -57,7 +56,6 @@ export function getPropsFromElementAttributes(element) {
         showRowNumbers: getShowRowNumbers(element),
         resourceBindings: getResourceBindings(element),
         resourceValues: getResourceValues(element),
-        partType: getPartType(element),
         enableLinks: getEnableLinks(element),
         order: getOrder(element)
     };
@@ -329,18 +327,6 @@ function getResourceBindings(element) {
 function getResourceValues(element) {
     const resourceValues = JSON.parse(element?.getAttribute("resourceValues"));
     return hasValue(resourceValues) && resourceValues;
-}
-
-/**
- * Retrieves the 'partType' attribute from the given HTML element.
- * If the attribute is not present or has no value, returns the default value "tiltakshaver".
- *
- * @param {Element} element - The HTML element from which to retrieve the 'partType' attribute.
- * @returns {string} The value of the 'partType' attribute, or "tiltakshaver" if not set.
- */
-function getPartType(element) {
-    const partType = element?.getAttribute("partType");
-    return hasValue(partType) ? partType : "tiltakshaver";
 }
 
 /**

--- a/src/functions/htmlElementHelpers.test.js
+++ b/src/functions/htmlElementHelpers.test.js
@@ -33,7 +33,6 @@ describe("getPropsFromElementAttributes", () => {
             showRowNumbers: "true",
             resourceBindings: JSON.stringify({ title: "res.title" }),
             resourceValues: JSON.stringify({ value: "res.value" }),
-            partType: "ansvarligSoeker",
             enableLinks: "true"
         });
 
@@ -62,22 +61,7 @@ describe("getPropsFromElementAttributes", () => {
         expect(props.showRowNumbers).toBe(true);
         expect(props.resourceBindings).toEqual({ title: "res.title" });
         expect(props.resourceValues).toEqual({ value: "res.value" });
-        expect(props.partType).toBe("ansvarligSoeker");
         expect(props.enableLinks).toBe(true);
-    });
-
-    test('defaults partType to "tiltakshaver" when not provided', () => {
-        const element = createElementWithAttributes({
-            formdata: JSON.stringify({ x: 1 }),
-            texts: JSON.stringify({}),
-            styleOverride: JSON.stringify({ some: "override" }),
-            tableColumns: JSON.stringify([]),
-            resourceBindings: JSON.stringify({}),
-            resourceValues: JSON.stringify({})
-        });
-
-        const props = getPropsFromElementAttributes(element);
-        expect(props.partType).toBe("tiltakshaver");
     });
 
     test("boolean attributes return false when set to other values", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.7"
     jest: "npm:^30.3.0"
     jest-environment-jsdom: "npm:^30.3.0"
-    jsdom: "npm:^29.1.0"
+    jsdom: "npm:^29.1.1"
     mini-css-extract-plugin: "npm:^2.10.2"
     prettier: "npm:3.8.3"
     style-loader: "npm:^4.0.0"
@@ -6358,7 +6358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom@npm:^29.1.0":
+"jsdom@npm:^29.1.1":
   version: 29.1.1
   resolution: "jsdom@npm:29.1.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@arkitektum/altinn-studio-custom-components-utils@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@arkitektum/altinn-studio-custom-components-utils@npm:1.4.3"
-  checksum: 10c0/649712c1daa99a43f661feef2e4ddce22ffd2646846c50af7478c84a2dc408961b7ed59eea1e561dc150fa1bae76e074dbaf8f95945052af4e61bfce346f2901
+"@arkitektum/altinn-studio-custom-components-utils@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "@arkitektum/altinn-studio-custom-components-utils@npm:1.4.4"
+  checksum: 10c0/fa53192d5a2e98e68673becacce0d6d56786c5ab47c7d67b5be3b79f70f55986b299f0cdee7d69ae0a83560a119916a4eb43f0e756701cec3fec09f5069b6860
   languageName: node
   linkType: hard
 
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@arkitektum/altinn-studio-custom-components@workspace:."
   dependencies:
-    "@arkitektum/altinn-studio-custom-components-utils": "npm:^1.4.3"
+    "@arkitektum/altinn-studio-custom-components-utils": "npm:^1.4.4"
     "@babel/preset-env": "npm:^7.29.2"
     "@eslint/js": "npm:^10.0.1"
     copyfiles: "npm:^2.4.1"


### PR DESCRIPTION
Refactored resource IDs and removed the `partType` property from UI components.

This pull request streamlines resource key management by removing a dynamic `partType` property from `CustomTablePart` and related helpers, and standardizes several resource IDs for improved consistency across the application.

### Breaking changes

- Components that previously relied on `partType` to dynamically set a title other than "tiltakshaver" will now default to `resource.tiltakshaver.title` unless a specific title is provided via `resourceBindings`.

### Changes

- The `partType` property and associated logic have been removed from the `CustomTablePart` class, `htmlElementHelpers`, and their respective test files.
- Rendering functions for various layout components (e.g., `dispensasjon`, `gjennomfoeringsplan`, `gjenpart-nabovarsel`, `custom-grouplist-nabo-gjenboer-eiendom`) no longer pass a `partType` attribute.
- Dynamic resource key generation in `CustomTablePart` has been removed, defaulting to `resource.tiltakshaver.title` for generic part titles if no explicit `resourceBindings.title` is provided.
- Resource IDs for "tiltakshaverKontaktperson" were refactored from `resource.tiltakshaver.kontaktperson.title` to `resource.kontaktpersonForTiltakshaver.title`.
- Resource IDs for "ansvarligSoeker" were refactored from `resource.ansvarligSoeker.title` to `resource.soeker.title`.
- Resource IDs for "eier" were refactored from `resource.eier.title` to `resource.eierFesterAvNaboeiendom.title`.
- New resource entries (`resource.kontaktpersonForSoeker.title`, `resource.kontaktpersonForTiltakshaver.title`) were added to `resource.nb.json` and `resources.json`.
- `replacedWithId` metadata was added to `resources.json` for deprecated resource IDs.
- The term `parttype` was removed from the VS Code spell checker dictionary.

### Impact

- Simplifies `CustomTablePart` by removing a layer of abstraction for dynamic title generation.
- Standardizes resource keys, enhancing consistency and maintainability of internationalization.
- Old resource IDs such as `resource.tiltakshaver.kontaktperson.title` and `resource.eier.title` are deprecated/replaced, requiring use of the new, more specific IDs.
- Minor cleanup of development environment settings.
