### PR TITLE
Fix: Retrieve Altinn App Frontend version using data attribute

### DIFF
--- a/src/functions/init.js
+++ b/src/functions/init.js
@@ -36,7 +36,7 @@ export default async function initCustomComponents() {
     const app = appId?.[2];
     const altinnAppFrontendVersionFallback = "4.29.0";
     const altinnAppFrontendVersion =
-        document.querySelector("meta[name='altinn-app-frontend-version']")?.getAttribute("content") || altinnAppFrontendVersionFallback;
+        document.querySelector("meta[data-altinn-app-frontend-version]")?.dataset?.altinnAppFrontendVersion || altinnAppFrontendVersionFallback;
     if (!origin || !org || !app) {
         console.error("Could not determine the origin, organization, or application from the URL.");
         return;


### PR DESCRIPTION
Adapts the version getter to use the `data-altinn-app-frontend-version` attribute, ensuring the correct frontend version is always retrieved from the meta tag.