### PR TITLE
Fix: Set global variables directly on globalThis

### DIFF
--- a/src/functions/init.js
+++ b/src/functions/init.js
@@ -66,12 +66,10 @@ export default async function initCustomComponents() {
         fetchDefaultTextResources(origin, org, app, selectedLanguage, fallbackLanguage)
     ]);
 
-    globalThis.appConfig = {
-        ...(globalThis.appConfig || {}),
-        selectedLanguage,
-        textResources,
-        defaultTextResources
-    };
+    globalThis.selectedLanguage = selectedLanguage;
+    globalThis.textResources = textResources;
+    globalThis.defaultTextResources = defaultTextResources;
+
     await loadScriptAsync(`https://altinncdn.no/toolkits/altinn-app-frontend/${altinnAppFrontendVersion}/altinn-app-frontend.js`);
 
     const domContentLoadedEvent = new Event("DOMContentLoaded", {


### PR DESCRIPTION
Moved selected language and text resources from globalThis.appConfig to direct properties on globalThis for simplified access.