### PR TITLE
Feature: Override padding introduced by Altinn App Frontend 4.28.0

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -204,6 +204,9 @@ body {
             }
         }
     }
+    [id^="form-content-"] {
+        padding: 0 !important;
+    }
 }
 
 /*


### PR DESCRIPTION
The Altinn App Frontend version 4.28.0 introduced unwanted padding on some `form-content-*` elements. This change adds a CSS rule to explicitly remove this padding, ensuring a consistent layout.