### PR TITLE
Feature/add group component for dispensasjon oversikt

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     },
     "packageManager": "yarn@4.10.3",
     "dependencies": {
-        "@arkitektum/altinn-studio-custom-components-utils": "^1.4.5"
+        "@arkitektum/altinn-studio-custom-components-utils": "^1.4.6"
     }
 }

--- a/src/classes/system-classes/component-classes/CustomGroupDispensasjonOversikt.js
+++ b/src/classes/system-classes/component-classes/CustomGroupDispensasjonOversikt.js
@@ -1,0 +1,124 @@
+// Dependencies
+import { getTextResourceFromResourceBinding, hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Classes
+import CustomComponent from "../CustomComponent.js";
+import DispensasjonOversikt from "../../data-classes/DispensasjonOversikt.js";
+
+// Global functions
+import { hasMissingTextResources, hasValidationMessages } from "../../../functions/validations.js";
+import { getComponentDataValue } from "../../../functions/helpers.js";
+
+/**
+ * CustomGroupDispensasjonOversikt is a custom component class that extends the base CustomComponent class.
+ *
+ * @extends CustomComponent
+ *
+ * @param {Object} props - The properties for initializing the component.
+ * @param {Object} [props.resourceBindings] - Custom resource binding values for fields.
+ * @param {Object} [props.resourceValues] - Custom resource values for fields.
+ *
+ * @property {boolean} isEmpty - Indicates if the dispensasjon data is empty.
+ * @property {Array|string|boolean} validationMessages - Validation messages for missing text resources.
+ * @property {boolean} hasValidationMessages - Indicates if there are validation messages.
+ * @property {Object} resourceBindings - Resource bindings for component fields.
+ * @property {Object} resourceValues - Resource values for title and data.
+ *
+ * @returns {CustomGroupDispensasjonOversikt} An instance of CustomGroupDispensasjonOversikt initialized with the provided properties.
+ */
+export default class CustomGroupDispensasjonOversikt extends CustomComponent {
+    constructor(props) {
+        super(props);
+        const data = this.getValueFromFormData(props);
+        const resourceBindings = this.getResourceBindings(props);
+        const isEmpty = !this.hasContent(data);
+        const validationMessages = this.getValidationMessages(resourceBindings);
+
+        this.isEmpty = isEmpty;
+        this.validationMessages = validationMessages;
+        this.hasValidationMessages = hasValidationMessages(validationMessages);
+        this.resourceBindings = resourceBindings || {};
+        this.resourceValues = {
+            title: hasValue(props?.resourceValues?.title)
+                ? props?.resourceValues?.title
+                : getTextResourceFromResourceBinding(resourceBindings?.dispensasjonOversikt?.title),
+            data: isEmpty ? getTextResourceFromResourceBinding(resourceBindings?.dispensasjonOversikt?.emptyFieldText) : data
+        };
+    }
+
+    /**
+     * Checks if the provided data has a value.
+     *
+     * @param {*} data - The data to check for content.
+     * @returns {boolean} Returns true if the data has a value, otherwise false.
+     */
+    hasContent(data) {
+        return hasValue(data);
+    }
+
+    /**
+     * Retrieves validation messages based on provided resource bindings.
+     *
+     * @param {Object} resourceBindings - The resource bindings to check for missing text resources.
+     * @returns {Array|string|boolean} - The result of checking for missing text resources, which may be an array of messages, a string, or a boolean depending on implementation.
+     */
+    getValidationMessages(resourceBindings) {
+        return hasMissingTextResources(resourceBindings);
+    }
+
+    /**
+     * Retrieves the value from the form data and initializes a DispensasjonOversikt instance.
+     *
+     * @param {*} props - The properties object containing form data.
+     * @returns {DispensasjonOversikt} An instance of DispensasjonOversikt initialized with the form data.
+     */
+    getValueFromFormData(props) {
+        const data = getComponentDataValue(props);
+        const dispensasjonOversikt = new DispensasjonOversikt(data);
+        return dispensasjonOversikt;
+    }
+
+    /**
+     * Retrieves resource bindings based on provided properties.
+     *
+     * @param {*} props - The properties object containing resource bindings.
+     * @returns {Object} An object containing the resource bindings for the component.
+     */
+    getResourceBindings(props) {
+        const resourceBindings = {
+            count: {
+                title: props?.resourceBindings?.count?.title || "resource.dispensasjonOversikt.dispensasjon.count.title",
+                emptyFieldText: props?.resourceBindings?.count?.emptyFieldText || "resource.emptyFieldText.zero"
+            },
+            dispensasjon: {
+                rowNumberTitle: props?.resourceBindings?.dispensasjon?.rowNumberTitle || "resource.nummer.short",
+                dispensasjonKategori: props?.resourceBindings?.dispensasjon?.dispensasjonKategori || "resource.kategori.title",
+                dispensasjonTittel: props?.resourceBindings?.dispensasjon?.dispensasjonTittel || "resource.emne.title",
+                bestemmelserType:
+                    props?.resourceBindings?.dispensasjon?.bestemmelserType || "resource.dispensasjonOversikt.dispensasjon.bestemmelserType.title",
+                emptyFieldText: props?.resourceBindings?.dispensasjon?.emptyFieldText || "resource.emptyFieldText.default"
+            }
+        };
+        if (props?.hideTitle !== true && props?.hideTitle !== "true") {
+            resourceBindings.dispensasjonOversikt = {
+                title: props?.resourceBindings?.title || "resource.dispensasjonOversikt.header"
+            };
+        }
+        if (props?.hideIfEmpty !== true && props?.hideIfEmpty !== "true") {
+            resourceBindings.dispensasjonOversikt = {
+                ...resourceBindings.dispensasjonOversikt,
+                emptyFieldText: props?.resourceBindings?.emptyFieldText || "resource.emptyFieldText.default"
+            };
+        }
+        return resourceBindings;
+    }
+
+    /**
+     * Retrieves the component usage, which is an array of custom component names that this class utilizes.
+     *
+     * @returns {Array<string>} An array of custom component names used by this class.
+     */
+    getComponentUsage() {
+        return ["custom-feedbacklist-validation-messages", "custom-field-count-data", "custom-header-text", "custom-paragraph", "custom-table-data"];
+    }
+}

--- a/src/classes/system-classes/component-classes/CustomGroupDispensasjonOversikt.test.js
+++ b/src/classes/system-classes/component-classes/CustomGroupDispensasjonOversikt.test.js
@@ -1,0 +1,131 @@
+import CustomGroupDispensasjonOversikt from "./CustomGroupDispensasjonOversikt";
+import DispensasjonOversikt from "../../data-classes/DispensasjonOversikt";
+
+jest.mock("../../data-classes/DispensasjonOversikt");
+
+const mockGetTextResourceFromResourceBinding = jest.fn();
+let mockHasValueImpl = (v) => v !== undefined && v !== null && v !== "";
+jest.mock("@arkitektum/altinn-studio-custom-components-utils", () => ({
+    getTextResourceFromResourceBinding: (...args) => mockGetTextResourceFromResourceBinding(...args),
+    hasValue: jest.fn((v) => mockHasValueImpl(v))
+}));
+
+const mockHasMissingTextResources = jest.fn();
+const mockHasValidationMessages = jest.fn();
+const mockGetComponentDataValue = jest.fn();
+jest.mock("../../../functions/validations", () => ({
+    hasMissingTextResources: (...args) => mockHasMissingTextResources(...args),
+    hasValidationMessages: (...args) => mockHasValidationMessages(...args)
+}));
+jest.mock("../../../functions/helpers", () => ({
+    getComponentDataValue: (...args) => mockGetComponentDataValue(...args)
+}));
+
+describe("CustomGroupDispensasjonOversikt", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        DispensasjonOversikt.mockClear();
+    });
+
+    it("should initialize with default resource bindings and values", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        mockGetTextResourceFromResourceBinding.mockReturnValue("defaultText");
+
+        const instance = new CustomGroupDispensasjonOversikt({});
+        expect(instance.isEmpty).toBe(false);
+        expect(instance.validationMessages).toEqual([]);
+        expect(instance.hasValidationMessages).toBe(false);
+        expect(instance.resourceBindings).toBeDefined();
+        expect(instance.resourceValues.title).toBe("defaultText");
+        expect(instance.resourceValues.data).toEqual({ data: "mockData" });
+    });
+
+    it("should set isEmpty true and use emptyFieldText if no data", () => {
+        mockGetComponentDataValue.mockReturnValue(undefined);
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        mockGetTextResourceFromResourceBinding.mockReturnValue("emptyText");
+        // Simulate hasValue returning false for the DispensasjonOversikt instance
+        mockHasValueImpl = () => false;
+
+        const instance = new CustomGroupDispensasjonOversikt({});
+        expect(instance.isEmpty).toBe(true);
+        expect(instance.resourceValues.data).toBe("emptyText");
+        // Restore default for other tests
+        mockHasValueImpl = (v) => v !== undefined && v !== null && v !== "";
+    });
+
+    it("should use provided resourceValues.title if present", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        const instance = new CustomGroupDispensasjonOversikt({
+            resourceValues: { title: "CustomTitle" }
+        });
+        expect(instance.resourceValues.title).toBe("CustomTitle");
+    });
+
+    it("should call hasMissingTextResources and hasValidationMessages", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue(["Missing"]);
+        mockHasValidationMessages.mockReturnValue(true);
+        const instance = new CustomGroupDispensasjonOversikt({});
+        expect(mockHasMissingTextResources).toHaveBeenCalled();
+        expect(mockHasValidationMessages).toHaveBeenCalledWith(["Missing"]);
+        expect(instance.validationMessages).toEqual(["Missing"]);
+        expect(instance.hasValidationMessages).toBe(true);
+    });
+
+    it("should set resourceBindings.dispensasjonOversikt.title if hideTitle is not true", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        const instance = new CustomGroupDispensasjonOversikt({});
+        expect(instance.resourceBindings.dispensasjonOversikt.title).toBeDefined();
+    });
+
+    it("should not set resourceBindings.dispensasjonOversikt.title if hideTitle is true", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        const instance = new CustomGroupDispensasjonOversikt({ hideTitle: true });
+        expect(instance.resourceBindings.dispensasjonOversikt?.title).toBeUndefined();
+    });
+
+    it("should set resourceBindings.dispensasjonOversikt.emptyFieldText if hideIfEmpty is not true", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        const instance = new CustomGroupDispensasjonOversikt({});
+        expect(instance.resourceBindings.dispensasjonOversikt.emptyFieldText).toBeDefined();
+    });
+
+    it("should not set resourceBindings.dispensasjonOversikt.emptyFieldText if hideIfEmpty is true", () => {
+        mockGetComponentDataValue.mockReturnValue("mockData");
+        DispensasjonOversikt.mockImplementation((data) => ({ data }));
+        mockHasMissingTextResources.mockReturnValue([]);
+        mockHasValidationMessages.mockReturnValue(false);
+        const instance = new CustomGroupDispensasjonOversikt({ hideIfEmpty: true });
+        expect(instance.resourceBindings.dispensasjonOversikt?.emptyFieldText).toBeUndefined();
+    });
+
+    it("getComponentUsage returns expected array", () => {
+        const instance = new CustomGroupDispensasjonOversikt({});
+        expect(instance.getComponentUsage()).toEqual([
+            "custom-feedbacklist-validation-messages",
+            "custom-field-count-data",
+            "custom-header-text",
+            "custom-paragraph",
+            "custom-table-data"
+        ]);
+    });
+});

--- a/src/components/data-components/custom-group-dispensasjon-oversikt/index.js
+++ b/src/components/data-components/custom-group-dispensasjon-oversikt/index.js
@@ -1,0 +1,45 @@
+// Dependencies
+import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+
+// Global functions
+import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
+import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+
+// Local functions
+import { renderDispensasjonCount, renderDispensasjonTable, renderEmptyFieldText, renderHeaderElement } from "./renderers.js";
+
+export default customElements.define(
+    "custom-group-dispensasjon-oversikt",
+    class extends HTMLElement {
+        async connectedCallback() {
+            const component = instantiateComponent(this);
+            const componentContainerElement = getComponentContainerElement(this);
+            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
+                if (isDevMode()) {
+                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
+                    if (hiddenEl) this.appendChild(hiddenEl);
+                } else {
+                    componentContainerElement.style.display = "none";
+                }
+            } else {
+                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                }
+                if (component?.isEmpty) {
+                    const emptyFieldTextElement = renderEmptyFieldText(component);
+                    this.appendChild(emptyFieldTextElement);
+                } else {
+                    this.appendChild(renderDispensasjonCount(component));
+                    this.appendChild(renderDispensasjonTable(component));
+                }
+                addDevToolsOverlay(this, component, "data");
+            }
+            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+            if (feedbackListElement) {
+                this.appendChild(feedbackListElement);
+            }
+        }
+    }
+);

--- a/src/components/data-components/custom-group-dispensasjon-oversikt/renderers.js
+++ b/src/components/data-components/custom-group-dispensasjon-oversikt/renderers.js
@@ -1,0 +1,114 @@
+// Dependencies
+import { CustomElementHtmlAttributes, addContainerElement, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
+
+/**
+ * Renders a custom header element with the specified title and size.
+ *
+ * @param {string} title - The title to display in the header element.
+ * @param {string} [size="h2"] - The size of the header element (e.g., "h1", "h2", "h3").
+ * @returns {HTMLElement} The created custom header element.
+ */
+export function renderHeaderElement(title, size = "h2") {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        size,
+        resourceValues: {
+            title
+        }
+    });
+    return createCustomElement("custom-header-text", htmlAttributes);
+}
+
+/**
+ * Renders a custom element displaying the count of dispensasjon data for a given component.
+ *
+ * @param {Object} component - The component object containing resource values and bindings.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {Object} [component.resourceBindings] - Resource bindings for the component.
+ * @returns {HTMLElement} The custom element with the specified attributes.
+ */
+export function renderDispensasjonCount(component) {
+    const data = component?.resourceValues?.data;
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: true,
+        resourceBindings: {
+            title: component?.resourceBindings?.count?.title,
+            emptyFieldText: component?.resourceBindings?.count?.emptyFieldText
+        },
+        resourceValues: {
+            data: data?.dispensasjon
+        }
+    });
+    return addContainerElement(createCustomElement("custom-field-count-data", htmlAttributes));
+}
+
+/**
+ * Renders a custom table element displaying dispensasjon data for a given component.
+ *
+ * @param {Object} component - The component object containing resource values and bindings.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {Object} [component.resourceBindings] - Resource bindings for the component.
+ * @returns {HTMLElement} The custom table element with the specified attributes.
+ */
+export function renderDispensasjonTable(component) {
+    const tableColumns = [
+        {
+            dataKey: "dispensasjonKategori.kodebeskrivelse",
+            tagName: "custom-field-data",
+            resourceBindings: {
+                title: component?.resourceBindings?.dispensasjon?.dispensasjonKategori,
+                emptyFieldText: component?.resourceBindings?.dispensasjon?.emptyFieldText
+            }
+        },
+        {
+            dataKey: "dispensasjonTittel.kodebeskrivelse",
+            tagName: "custom-field-data",
+            resourceBindings: {
+                title: component?.resourceBindings?.dispensasjon?.dispensasjonTittel,
+                emptyFieldText: component?.resourceBindings?.dispensasjon?.emptyFieldText
+            }
+        },
+        {
+            dataKey: "bestemmelserType.kodebeskrivelse",
+            tagName: "custom-field-data",
+            resourceBindings: {
+                title: component?.resourceBindings?.dispensasjon?.bestemmelserType,
+                emptyFieldText: component?.resourceBindings?.dispensasjon?.emptyFieldText
+            }
+        }
+    ];
+    const data = component?.resourceValues?.data;
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        hideIfEmpty: true,
+        resourceBindings: {
+            rowNumberTitle: component?.resourceBindings?.dispensasjon?.rowNumberTitle,
+            dispensasjonKategori: component?.resourceBindings?.dispensasjon?.dispensasjonKategori,
+            dispensasjonTittel: component?.resourceBindings?.dispensasjon?.dispensasjonTittel,
+            bestemmelserType: component?.resourceBindings?.dispensasjon?.bestemmelserType,
+            emptyFieldText: component?.resourceBindings?.dispensasjon?.emptyFieldText
+        },
+        resourceValues: { data: data?.dispensasjon },
+        tableColumns
+    });
+    return createCustomElement("custom-table-data", htmlAttributes);
+}
+
+/**
+ * Renders a custom paragraph element displaying the empty field text for a given component.
+ *
+ * @param {Object} component - The component object containing resource values.
+ * @param {Object} [component.resourceValues] - Resource values for the component.
+ * @param {string} [component.resourceValues.data] - The text to display as the empty field.
+ * @returns {HTMLElement} The custom paragraph element with the specified attributes.
+ */
+export function renderEmptyFieldText(component) {
+    const htmlAttributes = new CustomElementHtmlAttributes({
+        isChildComponent: true,
+        resourceValues: {
+            title: component?.resourceValues?.data
+        }
+    });
+    return addContainerElement(createCustomElement("custom-paragraph", htmlAttributes));
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,6 +29,7 @@ import customFieldUtfallSvarStatus from "./data-components/custom-field-utfall-s
 import customGroupAdkomst from "./data-components/custom-group-adkomst/index.js";
 import customGroupAnsvarsrettErklaeringer from "./data-components/custom-group-ansvarsrett-erklaeringer/index.js";
 import customGroupAvloep from "./data-components/custom-group-avloep/index.js";
+import customGroupDispensasjonOversikt from "./data-components/custom-group-dispensasjon-oversikt/index.js";
 import customGroupEttersending from "./data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js";
 import customGroupKontrollAnsvarsomraade from "./data-components/custom-group-kontroll-ansvarsomraade/index.js";
 import customGroupKontrollErklaeringer from "./data-components/custom-group-kontroll-erklaeringer/index.js";
@@ -122,6 +123,7 @@ export {
     customGroupAdkomst,
     customGroupAnsvarsrettErklaeringer,
     customGroupAvloep,
+    customGroupDispensasjonOversikt,
     customGroupEttersending,
     customGroupLoefteinnretninger,
     customGroupKontrollAnsvarsomraade,

--- a/src/functions/componentHelpers.js
+++ b/src/functions/componentHelpers.js
@@ -27,6 +27,7 @@ import CustomGjenpartNabovarsel from "../classes/system-classes/component-classe
 import CustomGroupAdkomst from "../classes/system-classes/component-classes/CustomGroupAdkomst.js";
 import CustomGroupAnsvarsrettErklaeringer from "../classes/system-classes/component-classes/CustomGroupAnsvarsrettErklaeringer.js";
 import CustomGroupAvloep from "../classes/system-classes/component-classes/CustomGroupAvloep.js";
+import CustomGroupDispensasjonOversikt from "../classes/system-classes/component-classes/CustomGroupDispensasjonOversikt.js";
 import CustomGroupEttersending from "../classes/system-classes/component-classes/CustomGroupEttersending.js";
 import CustomGroupKontrollAnsvarsomraade from "../classes/system-classes/component-classes/CustomGroupKontrollAnsvarsomraade.js";
 import CustomGroupKontrollErklaeringer from "../classes/system-classes/component-classes/CustomGroupKontrollErklaeringer.js";
@@ -109,6 +110,7 @@ export function getComponentForTagName(tagName) {
         "custom-group-adkomst": CustomGroupAdkomst,
         "custom-group-ansvarsrett-erklaeringer": CustomGroupAnsvarsrettErklaeringer,
         "custom-group-avloep": CustomGroupAvloep,
+        "custom-group-dispensasjon-oversikt": CustomGroupDispensasjonOversikt,
         "custom-group-ettersending": CustomGroupEttersending,
         "custom-group-kontroll-ansvarsomraade": CustomGroupKontrollAnsvarsomraade,
         "custom-group-kontroll-erklaeringer": CustomGroupKontrollErklaeringer,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@arkitektum/altinn-studio-custom-components-utils@npm:^1.4.5":
-  version: 1.4.5
-  resolution: "@arkitektum/altinn-studio-custom-components-utils@npm:1.4.5"
-  checksum: 10c0/d805caae173362dd315efda314c4ad5c06e2de5211d43fbf3eda5976aab31dfe21d80bacc73b4891b2868f1ba16fc9a7dc2e1a2ce594b6de7b1b42b2c39c160c
+"@arkitektum/altinn-studio-custom-components-utils@npm:^1.4.6":
+  version: 1.4.6
+  resolution: "@arkitektum/altinn-studio-custom-components-utils@npm:1.4.6"
+  checksum: 10c0/d8d64db8fe52ad28c358f85a6efbf64fa432aa31694c89f57a3bc397dd8ff4d12de3916dbcf871e1a476d62d793879a064ca5bfb811633660a4eee7d429271fd
   languageName: node
   linkType: hard
 
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@arkitektum/altinn-studio-custom-components@workspace:."
   dependencies:
-    "@arkitektum/altinn-studio-custom-components-utils": "npm:^1.4.5"
+    "@arkitektum/altinn-studio-custom-components-utils": "npm:^1.4.6"
     "@babel/preset-env": "npm:^7.29.5"
     "@eslint/js": "npm:^10.0.1"
     copyfiles: "npm:^2.4.1"
@@ -2630,9 +2630,9 @@ __metadata:
   linkType: hard
 
 "@types/estree@npm:*, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "@types/estree@npm:1.0.8"
-  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -2766,9 +2766,9 @@ __metadata:
   linkType: hard
 
 "@types/qs@npm:*":
-  version: 6.15.0
-  resolution: "@types/qs@npm:6.15.0"
-  checksum: 10c0/1b104cac50e655fc41d7fc1de2c2aba2908c4cf833a555b6808fb4c96752662b439238f2392a15d2590a7a6ca75dbd40e42d9378ac2be0d548ee484954363688
+  version: 6.15.1
+  resolution: "@types/qs@npm:6.15.1"
+  checksum: 10c0/1dfdbcb4cf2a8f66d57f0b9a9fe6b1c7091cb816687b6698c1351eaf31f62e412cea9b7453a9637b570cd5fad8dced527e5a9e69b4fcc6e318daacd8b749f094
   languageName: node
   linkType: hard
 
@@ -4553,9 +4553,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.328":
-  version: 1.5.351
-  resolution: "electron-to-chromium@npm:1.5.351"
-  checksum: 10c0/6f9193a2c49e6015768fe5bd7eaadafba4ab8486d5aeecb6e4fb9dd526ab43f8fc266f459784d3154dcc3501230531f54069d1d5009a489df78cbceb6bbf8a5d
+  version: 1.5.352
+  resolution: "electron-to-chromium@npm:1.5.352"
+  checksum: 10c0/d1672a327420ea0c5dffbd604c448e5bacf9238953f7ce464f3d31c98309bb5ebe82443fb2425de0a78db3ef89261356ee59967dbac866e16262b8bbc0a03209
   languageName: node
   linkType: hard
 
@@ -8585,8 +8585,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.10.0, terser@npm:^5.31.1":
-  version: 5.46.2
-  resolution: "terser@npm:5.46.2"
+  version: 5.47.0
+  resolution: "terser@npm:5.47.0"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.15.0"
@@ -8594,7 +8594,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10c0/476f1820160c42e6b2f611410115b00321c4666d421f12db87f13810f8789de45cb254e3ad5178650696d0ba6b706f5a0a239272255d6d1be95816c660f8cbbb
+  checksum: 10c0/98983d0b175e5fab1652e9e9a4a5d09bf4e5a80180a571d7e66df4b8956b0fcffe384f5f687c39c1bff14c51fc63d64a80967250f71a2208652da1f613254c8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Introduces `CustomGroupDispensasjonOversikt` component for displaying dispensation data.

<img width="747" height="237" alt="image" src="https://github.com/user-attachments/assets/8130cbeb-333c-4ef1-8e31-195f4d442d7d" />


This pull request adds a new custom component that aggregates and presents an overview of dispensation data, including a count and a detailed table, with conditional rendering based on data availability and validation status. It establishes a modular structure comprising a class for business logic, a web component for presentation, and dedicated renderers for sub-elements.

### Changes

- **New Component Definition**: Added `CustomGroupDispensasjonOversikt.js` which defines a new class extending `CustomComponent`. This class handles data retrieval, resource binding management (with default values and overrides), validation, and determines component state (e.g., `isEmpty`).
- **New Web Component Implementation**: Implemented `custom-group-dispensasjon-oversikt` (in `index.js`) as a new HTML custom element. Its `connectedCallback` orchestrates the rendering of sub-components such as headers, data counts, data tables, empty field text, and validation messages, based on the `CustomGroupDispensasjonOversikt` class instance.
- **Dedicated Rendering Functions**: Introduced `renderers.js` containing helper functions (`renderHeaderElement`, `renderDispensasjonCount`, `renderDispensasjonTable`, `renderEmptyFieldText`) that create and configure existing base custom components (e.g., `custom-header-text`, `custom-field-count-data`, `custom-table-data`, `custom-paragraph`) to display specific parts of the dispensation overview.
- **Resource Binding Logic**: The `getResourceBindings` method within `CustomGroupDispensasjonOversikt` provides a comprehensive set of default resource paths for titles, empty field texts, and table column headers, allowing extensive customization via props.
- **Conditional Rendering Logic**: The `custom-group-dispensasjon-oversikt` web component includes logic to hide itself if `hideIfEmpty` is true and data is absent, and to render an empty field message or the data elements accordingly.

### Impact

- **Behavioral Changes**: A new UI component `custom-group-dispensasjon-oversikt` becomes available, providing a structured overview of dispensation data. It conditionally displays a count, a detailed table, or an empty message based on data presence, and shows validation feedback.
- **Dependencies Affected**: This feature introduces new dependencies on core custom component utilities (`@arkitektum/altinn-studio-custom-components-utils`) and leverages several existing custom components: `custom-feedbacklist-validation-messages`, `custom-field-count-data`, `custom-header-text`, `custom-paragraph`, and `custom-table-data`. It also depends on a new `DispensasjonOversikt` data class.
- **Breaking Changes**: None, as this is an entirely new feature addition.
- **Performance Implications**: Minimal; the component's rendering involves instantiating and appending multiple child custom elements, which is a standard pattern for component composition.
