### PR TITLE
Feature/documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,233 @@
+# Architecture
+
+This document explains how `@arkitektum/altinn-studio-custom-components` is built, how it behaves at runtime, and how it fits into the wider ecosystem of packages and applications it belongs to.
+It is aimed at developers who maintain or extend the package.
+
+For installation and usage instructions, see the [README](./README.md).
+For how to contribute, see [CONTRIBUTING](./CONTRIBUTING.md).
+
+---
+
+## 1. What this package is
+
+A collection of reusable **custom HTML elements** (Web Components) for **Altinn Studio** apps.
+The components provide consistent, standardized presentation of domain data for digital public services, following standards from **Direktoratet for Byggkvalitet (DiBK)** on the **Fellestjenester BYGG** platform.
+
+The package is distributed as a set of static assets (`main.js`, `main.css`, fonts, and generated resource files) that an Altinn app copies into its `wwwroot` and loads in the browser.
+It is **not** a framework or a server component — everything runs client-side in the user's browser, both in the interactive form and in the generated PDF layout.
+
+---
+
+## 2. The ecosystem
+
+This repository is one of several related packages and applications.
+Understanding the boundaries between them is the key to understanding the architecture.
+
+| Repository / package | Role |
+| -------------------- | ---- |
+| **`altinn-studio-custom-components`** (this repo) | The custom components themselves. Published as `@arkitektum/altinn-studio-custom-components`. |
+| **`@arkitektum/altinn-studio-custom-components-utils`** | Shared functions and classes used across the packages — most importantly `createCustomElement`, `CustomElementHtmlAttributes`, and the **allow-list of valid custom-element tag names**. A runtime dependency of this package. |
+| **`@arkitektum/client-logger`** | Helper functions/classes for logging to Elastic from the browser. A runtime dependency of this package. |
+| **`altinn-studio-custom-components-api`** | A small Node API that backs the local **Statistics** dev tool (reads layouts, package versions, app resources, etc.). Not published; used only during development. |
+| **`altinn-studio-custom-components-docs`** | A GitHub Pages app that showcases every component with example data. The public component gallery. |
+| **Altinn apps** (e.g. the example app) | The .NET/Altinn applications that consume this package, reference it in `App/package.json`, and copy it into `App/wwwroot` at build time. |
+
+```text
+                          localhost:9001
+                     (custom-components-api)
+                              ▲
+                              │
+   client-logger    utils ────┼──── api repo
+        │             │       │
+        ▼             ▼       ▼
+  ┌───────────────────────────────────────┐        ┌──────────────── Altinn Studio ─────────────┐
+  │   @arkitektum/altinn-studio-          │        │  Altinn app                                │
+  │   custom-components  (THIS PACKAGE) ──┼───────▶│   App/package.json  → dependency           │
+  └───────────────────────────────────────┘        │   App/wwwroot       → copied assets        │
+        │            │              │              │   App/ui/*.json     → component usage      │
+        ▼            ▼              ▼              │   App/config/texts/resource.<lang>.json    │
+   devTools.html  statistics.html  docs site       │     → local resources (override globals)   │
+                                                   └────────────────────────────────────────────┘
+
+  Global resources:  src/data/resources.json ──▶ generated  src/data/resource.<lang>.json
+```
+
+See [`temp-data/relations.jpg`](./temp-data/relations.jpg) for the original overview sketch (note: `temp-data/` is working material and is not part of the published package).
+
+---
+
+## 3. Runtime model
+
+The package ships three webpack entry points (`src/components/index.js`, `public/scripts/devTools/index.js`, `public/scripts/statistics/index.js`), but only `main.js` (built from the components entry) is shipped to Altinn apps.
+devTools and statistics are development surfaces (see §7).
+
+### Bootstrapping in an Altinn app
+
+1. The app loads `main.css` and `main.js` from `wwwroot/altinn-studio-custom-components` (see the README installation steps).
+2. `src/functions/init.js` (`initCustomComponents`) runs on startup. It:
+   - derives `org`, `app`, and `instanceId` from the URL,
+   - fetches the user's profile to determine the preferred language (falling back to `nb`),
+   - loads the app's **text resources** and **default text resources** and stores them on `globalThis` (`globalThis.textResources`, `globalThis.defaultTextResources`, `globalThis.selectedLanguage`),
+   - dynamically loads the matching `altinn-app-frontend.js` bundle from the Altinn CDN (the version is read from a `meta[data-altinn-app-frontend-version]` tag, with a hard-coded fallback), and
+   - dispatches a `DOMContentLoaded` event so the components and the Altinn frontend initialize.
+3. Each custom element is registered via `customElements.define(...)` and renders itself in its `connectedCallback`.
+
+### How a component renders
+
+Each component's `index.js` is thin — it defines the custom element and delegates logic to a **component class**.
+The typical flow (see `src/components/data-components/custom-field-data/index.js`):
+
+1. `instantiateComponent(this)` builds the component-class instance from the element's attributes.
+2. If the component is configured with `hideIfEmpty` and resolves to empty, it is hidden (or shown as a placeholder in DevTools mode).
+3. Otherwise the class produces `CustomElementHtmlAttributes`, and `createCustomElement(...)` (from the utils package) renders the underlying base element into the DOM.
+
+---
+
+## 4. Source layout
+
+```text
+src/
+├── components/            # The custom elements (thin wrappers around component classes)
+│   ├── base-components/       # Primitive building blocks. Take literal values; not bound to
+│   │                          #   a data model or resources (custom-field, custom-table, ...)
+│   ├── data-components/       # Bound to the data model + resource files. The bulk of the package
+│   │                          #   (custom-field-data, custom-table-part, custom-group-*, ...)
+│   ├── layout-components/     # Whole-form layouts composed of many data/base components
+│   │                          #   (dispensasjon, gjennomfoeringsplan, ...)
+│   └── index.js               # Registers every component (webpack entry "main")
+│
+├── classes/
+│   ├── system-classes/
+│   │   ├── CustomComponent.js         # Base class for all component classes
+│   │   ├── ValidationMessages.js      # Validation message container
+│   │   ├── component-classes/         # One class per component (PascalCase), holds the logic
+│   │   └── data-classes/              # System-level data wrappers
+│   ├── data-classes/          # Domain data classes (Adresse, Ansvarsomraade, ...)
+│   └── layout-classes/        # Domain classes for layout components
+│
+├── constants/             # dateTimeFormats, urls (logger endpoints + Altinn origins)
+├── data/                  # resources.json (source) + generated resource.<lang>.json (see §5)
+├── fonts/                 # Bundled fonts (Roboto Flex, etc.)
+├── functions/             # Shared helpers (componentHelpers, helpers, init, clientLoggerHelpers,
+│                          #   devToolsHelpers, tableHelpers, validations, ...) + *.test.js
+└── styles/                # CSS
+
+public/                    # Dev-only HTML + scripts for the local playground, DevTools, Statistics
+scripts/                   # create-symlinks.js, generate-resource-files.js, ResourceGeneratorPlugin.js
+```
+
+### Component model
+
+There are three component categories, mirrored by the `base-components` / `data-components` / `layout-components` directories:
+
+- **Base components** — the most primitive building blocks (e.g. `custom-field`, `custom-paragraph`, `custom-table`).
+  They accept literal values as props and are not connected to a data model or to resources.
+- **Data components** — connected to a data model.
+  They read values from the model and text from the resource files.
+  The tag name encodes intent: the part after `custom-` (`field`, `paragraph`, `table`, `group`, `grouplist`, …) indicates the rendering shape, and the suffix indicates the concrete class/data type (or generic `data` / `text`).
+  A data component's children may be base components or other data components.
+- **Layout components** — like a group data component, but represent a complete form layout composed of multiple data and base components.
+
+### Component classes
+
+Every data and layout component has a class in `src/classes/system-classes/component-classes/[ComponentTagName].js` (PascalCase) that extends `CustomComponent`.
+By convention these classes implement:
+
+| Method | Responsibility |
+| ------ | -------------- |
+| `getValueFromFormData` | Resolve the value — from `resourceValues` or by reading the binding from the data model. Often wraps the value in a domain data class. |
+| `getResourceBindings` | Return all resource bindings the component needs. Every binding has a default and can be overridden. |
+| `getComponentUsage` | List the tag names of the component's direct children. Used by the Statistics tool to know which components are used indirectly. |
+| `getValidationMessages` | Apply the component's validation rules and return a `ValidationMessages` object (often via `hasMissingTextResources`). |
+| `hasContent` | Decide whether the component actually renders anything; drives `isEmpty` and therefore `hideIfEmpty`. Returns `true` only if something will actually be rendered. |
+
+---
+
+## 5. Resource (i18n) system
+
+Text resources are multilingual and live in **`src/data/resources.json`**, the single source of truth.
+Each entry has an `id` and a `values` map keyed by language code:
+
+```json
+{
+  "id": "resource_id",
+  "values": { "nb": "Bokmål", "nn": "Nynorsk", "en": "English" }
+}
+```
+
+- The **`ResourceGeneratorPlugin`** (webpack) and `scripts/generate-resource-files.js` read `resources.json` and emit one file per language, `src/data/resource.<lang>.json`, containing only that language's values.
+  **These generated files must not be edited by hand** — change `resources.json` and they are regenerated (the dev server regenerates and re-sorts by `id` on save).
+- `create-symlinks.js` links the generated files into `public/data/` for the dev playground.
+- `copy-dist-resources` (in the `build` script) copies the resource files into `dist/` for publishing.
+
+### Override behavior in Altinn apps
+
+A consuming Altinn app keeps its **own** `App/config/texts/resource.<lang>.json` with app-specific resources.
+If a local resource shares an `id` with one shipped by this package, **the app's local value wins**.
+This lets apps override a global/common resource value.
+
+---
+
+## 6. Security model: the tag-name allow-list
+
+Custom elements are only rendered through `createCustomElement(tagName, attributes)` in the utils package, which throws `Invalid tag name` unless `tagName` is present in `customElementTagNames` (`isValidTagName`).
+This allow-list — maintained in `@arkitektum/altinn-studio-custom-components-utils` — is the central guard that prevents arbitrary element names from being injected at render time.
+**A new component's tag name must be added to that list or it will not render.**
+See [SECURITY.md](./SECURITY.md) for the threat model.
+
+---
+
+## 7. Development surfaces
+
+The dev server (`yarn start`, webpack-dev-server) serves a local playground in addition to the shipped bundle:
+
+- **`index.html`** — the component playground / tester.
+- **`devTools.html`** — DevTools overlay mode (also reachable in a real app via `?devtools=true`).
+  Each component gets an inspection badge color-coded by category (Base / Data / Layout).
+  See the README for details.
+- **`statistics.html`** — a dashboard that analyzes component usage and resource coverage across apps.
+  It calls the local **`altinn-studio-custom-components-api`** on `API_PORT` (default `9001`) and therefore requires a Gitea token in `.env` (see [CONTRIBUTING](./CONTRIBUTING.md)).
+
+These surfaces are development-only and are not part of the published `dist/`.
+
+---
+
+## 8. Logging
+
+Browser-side logging goes through `@arkitektum/client-logger` (wrapped in `src/functions/clientLoggerHelpers.js`).
+API/fetch calls log result, errors, warnings, and response time to **Elastic**.
+The target endpoint is environment-aware — `src/constants/urls.js` maps the current Altinn app origin (local / test / production) to the matching `frontendlogger.*.dibk.no` URL.
+
+---
+
+## 9. Build & release pipeline
+
+The `build` script runs three steps:
+
+```text
+yarn symlinks            # create-symlinks.js   → link generated resources into public/data
+NODE_ENV=production webpack   # bundle to dist/  (uses webpack.config.js)
+yarn copy-dist-resources # copy src/data/resource.*.json + resources.json into dist/
+```
+
+Only `dist/` and `README.md` are published (`package.json#files`).
+`dist/main.js` is the package entry (`main` / `module`).
+
+**Tooling:** Node.js 24, Yarn 4 via Corepack (pinned through `packageManager`), Webpack 5, Babel, Jest (jsdom), ESLint (flat config) and Prettier.
+
+**CI** (`.github/workflows/`):
+
+- `ci.yml` — install, `yarn test`, `yarn build` on push/PR to `main`.
+- `eslint.yml` — ESLint scan, uploads SARIF to the GitHub Security tab (also on a weekly schedule).
+- `build-and-publish-to-npm.yml` / `build-and-publish-to-github.yml` — on GitHub **release created**: install, test, build, then publish to npm (with `--provenance`) and to GitHub Packages.
+  The dist-tag is derived from the release tag — a tag containing `-` (e.g. `1.2.3-beta.1`) publishes under that prerelease tag, otherwise `latest`.
+
+---
+
+## 10. Conventions
+
+- **Web standards first.** Components are native custom elements; there is no UI framework runtime.
+- **Thin elements, fat classes.** Element `index.js` files only register and delegate; logic lives in the component class.
+- **JSDoc** on classes and exported functions.
+- **Tests** are colocated as `*.test.js` next to the unit under test and run with Jest.
+- **Formatting/linting** via Prettier (`.prettierrc`) and ESLint (`eslint.config.mjs`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,14 @@ For a high-level picture of how the package and its sibling repositories fit tog
    ```
 
    - `PORT` — dev server port (default `9000`).
-   - `API_PORT` and `GITEA_TOKEN` — **only** needed for the local **Statistics** dashboard, which talks to the `altinn-studio-custom-components-api`.
+   - `API_PORT` and `GITEA_TOKEN` — **only** needed for the local **Statistics** dashboard.
      You can skip these for ordinary component work.
 
-   To use the Statistics dashboard, generate a Gitea token:
+   The Statistics dashboard calls a separate backend, the [`altinn-studio-custom-components-api`](https://github.com/Arkitektum/altinn-studio-custom-components-api) repository, on `http://localhost:<API_PORT>` (default `9001`).
+   To use the dashboard you must also clone that repo and run it (`yarn start`) with a matching `API_PORT`.
+   Both this app and the API read `GITEA_TOKEN` from their own `.env`.
+
+   To generate a Gitea token:
    - Go to <https://altinn.studio/repos/user/settings/applications>
    - Create a token with the **`read:repository`** scope
    - Put it in `.env` as `GITEA_TOKEN` (replacing `your_token_here`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,157 @@
+# Contributing
+
+Thanks for contributing to `@arkitektum/altinn-studio-custom-components`!
+This guide covers local setup, the development workflow, and the conventions for adding components and resources.
+
+For a high-level picture of how the package and its sibling repositories fit together, read [ARCHITECTURE.md](./ARCHITECTURE.md) first.
+
+---
+
+## Prerequisites
+
+- **Node.js 24**
+- **Yarn 4**, managed via [Corepack](https://nodejs.org/api/corepack.html). Enable it once:
+
+  ```bash
+  corepack enable
+  ```
+
+  The correct Yarn version is then activated automatically from the `packageManager` field in `package.json`.
+  (The CI removes any preinstalled Yarn 1 and uses Corepack — do the same locally if `yarn --version` does not report `4.x`.)
+
+---
+
+## Getting started
+
+1. **Clone and install**
+
+   ```bash
+   git clone https://github.com/Arkitektum/altinn-studio-custom-components.git
+   cd altinn-studio-custom-components
+   yarn install
+   ```
+
+2. **Create your `.env`**
+
+   ```bash
+   cp .env.sample .env
+   ```
+
+   - `PORT` — dev server port (default `9000`).
+   - `API_PORT` and `GITEA_TOKEN` — **only** needed for the local **Statistics** dashboard, which talks to the `altinn-studio-custom-components-api`.
+     You can skip these for ordinary component work.
+
+   To use the Statistics dashboard, generate a Gitea token:
+   - Go to <https://altinn.studio/repos/user/settings/applications>
+   - Create a token with the **`read:repository`** scope
+   - Put it in `.env` as `GITEA_TOKEN` (replacing `your_token_here`)
+
+   > ⚠️ `.env` is git-ignored. Never commit tokens or secrets.
+
+3. **Start the dev server**
+
+   ```bash
+   yarn start
+   ```
+
+   Open <http://localhost:9000>.
+   The playground links to a component tester, the **Developer tools** page, and the **Statistics** page.
+
+---
+
+## Everyday commands
+
+| Command | What it does |
+| ------- | ------------ |
+| `yarn start` | Start the webpack dev server / playground. |
+| `yarn test` | Run the Jest unit tests. |
+| `yarn lint` | Run ESLint over `src`. |
+| `yarn build` | Produce the publishable bundle in `dist/`. |
+
+Before opening a pull request, make sure `yarn test`, `yarn lint`, and `yarn build` all pass — CI runs the same checks.
+
+---
+
+## Adding a new component
+
+1. **Create the element directory** under `src/components/<component-type>/<component-tag-name>/` and add the files it needs (`index.js`, plus `README.md`, `styles.css`, etc. as appropriate).
+   `<component-type>` is one of:
+   - `base-components` — primitive building blocks; accept literal values; not bound to a data model or resources.
+   - `data-components` — bound to the data model and resources.
+     The first segment after `custom-` (`field`, `paragraph`, `table`, `group`, `grouplist`, …) signals the rendering shape; the suffix names the class/data type (or generic `data` / `text`).
+     Children may be base components or other data components.
+   - `layout-components` — a complete form layout composed of multiple data and base components.
+
+2. **Register the element** by importing it in `src/components/index.js`.
+
+3. **Add the component class** in `src/classes/system-classes/component-classes/<ComponentTagName>.js` (PascalCase), extending `CustomComponent`.
+   Data and layout components should implement:
+
+   - `getValueFromFormData` — resolve the value from `resourceValues` or the data-model binding; often instantiate a domain data class from `src/classes/data-classes` or `src/classes/system-classes/data-classes`.
+   - `getResourceBindings` — return all resource bindings; each must have a default value and be overridable.
+   - `getComponentUsage` — return the tag names of the component's direct children (used by the Statistics tool).
+   - `getValidationMessages` — return a `ValidationMessages` object (often via `hasMissingTextResources`, passing the bindings from `getResourceBindings`).
+   - `hasContent` — drive the `isEmpty` / `hideIfEmpty` behavior.
+     Return `true` **only** if the component will actually render something (e.g. if it has data but nothing is rendered, return `false`).
+
+4. **Register the tag name in the allow-list.**
+   Add the new tag name to `customElementTagNames.js` in the [`altinn-studio-custom-components-utils`](https://github.com/Arkitektum/altinn-studio-custom-components-utils) package.
+   This is required for security reasons — `createCustomElement` throws for any tag name not on the list, so the component will not render until it is added (and the updated utils version is released and bumped here).
+
+5. **Add tests.**
+   Place `*.test.js` next to the class/functions you add and cover the logic with Jest.
+
+6. **Document it.**
+   Add an example with dummy data to the [`altinn-studio-custom-components-docs`](https://github.com/Arkitektum/altinn-studio-custom-components-docs) gallery.
+
+---
+
+## Adding, removing, or changing a resource
+
+- Edit **`src/data/resources.json`** — the single source of truth. Each entry:
+
+  ```json
+  {
+    "id": "resource_id",
+    "values": { "nb": "Bokmål", "nn": "Nynorsk", "en": "English" }
+  }
+  ```
+
+  To add a resource, append a new object with a unique `id` and a value per supported language.
+  While the dev server runs, saving the file re-sorts entries by `id` automatically.
+
+- **Do not edit `src/data/resource.<lang>.json` by hand.**
+  Those per-language files are generated from `resources.json` and are regenerated on save / build.
+
+- **Overrides:** a consuming Altinn app may define the same `id` in its own `App/config/texts/resource.<lang>.json`; the app's local value takes precedence over the value shipped here.
+
+---
+
+## Coding conventions
+
+- **Web standards first** — components are native custom elements; there is no UI framework runtime.
+- **Thin elements, fat classes** — keep element `index.js` files limited to registration and delegation; put logic in the component class.
+- **JSDoc** on classes and exported functions.
+- **Formatting & linting** via Prettier (`.prettierrc`) and ESLint (`eslint.config.mjs`).
+  Run `yarn lint` before pushing.
+- **Tests** colocated as `*.test.js` and run with Jest.
+
+---
+
+## Pull requests
+
+1. Branch off `main`.
+2. Keep changes focused; update or add tests and documentation.
+3. Ensure `yarn test`, `yarn lint`, and `yarn build` pass locally.
+4. Open a PR against `main`. CI (`ci.yml` and the ESLint scan) must be green before merge.
+
+---
+
+## Versioning & releases
+
+- Releases are **triggered by creating a GitHub Release**.
+  The publish workflows then install, test, build, and publish to **npm** (with provenance) and to **GitHub Packages**.
+- The npm **dist-tag** is derived from the release tag: a tag containing a hyphen (e.g. `1.2.3-beta.1`) is published under that prerelease tag; otherwise it goes to `latest`.
+- Bump the version in `package.json` as part of the change that warrants a release, following semantic versioning.
+
+> Only maintainers can publish releases.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ For a full list of available components and examples, see the documentation site
 
 ## 🧪 Development & Testing
 
+> For a deeper look at how the package is structured and how it fits into the wider ecosystem, see [ARCHITECTURE.md](./ARCHITECTURE.md). For contribution guidelines (adding components, resources, releases), see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ### Prerequisites
 
 - **Node.js 24**
@@ -195,6 +197,9 @@ Clicking anywhere outside a panel closes it.
 
 ## 🔗 Resources
 
+- [Architecture overview](./ARCHITECTURE.md)
+- [Contributing guide](./CONTRIBUTING.md)
+- [Security policy](./SECURITY.md)
 - [Altinn Studio Documentation](https://docs.altinn.studio/)
 - [Altinn Studio GitHub Repository](https://github.com/Altinn/altinn-studio)
 - [Altinn Studio Custom Component Documentation](https://docs.altinn.studio/altinn-studio/reference/ux/components/custom/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,5 +59,5 @@ A few properties of the design are relevant when assessing security:
 ## Dependencies
 
 Runtime dependencies are limited to other Arkitektum packages (`@arkitektum/altinn-studio-custom-components-utils`, `@arkitektum/client-logger`).
-Dependency lint and code scanning run in CI (see `.github/workflows/eslint.yml`, which uploads results to the GitHub Security tab).
+Static analysis of the source runs in CI via ESLint (`.github/workflows/eslint.yml`), which uploads results to the GitHub Security tab.
 If you find a vulnerability in a dependency, please report it to that project as well.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are released against the **latest published version** of `@arkitektum/altinn-studio-custom-components` on npm.
+Please make sure you can reproduce an issue on the latest release before reporting it, and upgrade to the latest version to receive fixes.
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | ✅ |
+| Older releases | ❌ (please upgrade) |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues, pull requests, or discussions.**
+
+Instead, report them privately through GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab: <https://github.com/Arkitektum/altinn-studio-custom-components/security>
+2. Click **Report a vulnerability** to open a private advisory.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact.
+- The affected version(s) and the environment (e.g. Altinn app, the standalone dev playground).
+- Step-by-step instructions to reproduce, including a minimal proof of concept if possible.
+- Any suggested remediation.
+
+### What to expect
+
+- We will acknowledge your report and begin investigating.
+- We will keep you informed of progress and let you know when a fix is released.
+- Please give us a reasonable amount of time to release a fix before any public disclosure.
+  We are happy to credit reporters who wish to be acknowledged.
+
+## Scope and security model
+
+This package renders standardized presentation components inside **Altinn Studio** apps.
+A few properties of the design are relevant when assessing security:
+
+- **Tag-name allow-list.**
+  Custom elements are only created through `createCustomElement`, which rejects any tag name not present in the `customElementTagNames` allow-list maintained in [`@arkitektum/altinn-studio-custom-components-utils`](https://github.com/Arkitektum/altinn-studio-custom-components-utils).
+  This is an intentional guard against arbitrary element injection; changes to it deserve extra scrutiny.
+- **Data sources.**
+  Components read data from the Altinn app's data model and from text resources.
+  Treat all such data as untrusted and validate/escape appropriately when rendering.
+- **Logging.**
+  The package logs to Elastic via [`@arkitektum/client-logger`](https://github.com/Arkitektum/client-logger).
+  Avoid logging personal data (PII) or secrets.
+  Log messages should contain only what is needed for diagnostics.
+- **Secrets.**
+  No secrets belong in this repository.
+  The only token used during development is a Gitea `read:repository` token for the local **Statistics** dashboard; it lives in a git-ignored `.env` file and is never bundled or published.
+  See [CONTRIBUTING.md](./CONTRIBUTING.md).
+- **Published surface.**
+  Only `dist/` and `README.md` are published to npm.
+  Development surfaces (the playground, DevTools, and Statistics pages under `public/`) are **not** part of the published package.
+
+## Dependencies
+
+Runtime dependencies are limited to other Arkitektum packages (`@arkitektum/altinn-studio-custom-components-utils`, `@arkitektum/client-logger`).
+Dependency lint and code scanning run in CI (see `.github/workflows/eslint.yml`, which uploads results to the GitHub Security tab).
+If you find a vulnerability in a dependency, please report it to that project as well.


### PR DESCRIPTION
# Add project documentation (README, ARCHITECTURE, CONTRIBUTING, SECURITY)

## Summary

This PR rounds out the repository's documentation.
It adds three new top-level documents — `ARCHITECTURE.md`, `CONTRIBUTING.md`, and `SECURITY.md` — and expands the existing `README.md` so new contributors and package consumers can get oriented without reading the source.

All four files are grounded in the actual code, build scripts, and CI workflows (verified against `package.json`, the webpack configs, `src/`, and `.github/workflows/`), and they cross-link to each other for discoverability.

## What's included

| File | Status | Purpose |
| ---- | ------ | ------- |
| `README.md` | Updated | Installation/usage, development & testing, links to the new docs. |
| `ARCHITECTURE.md` | New | How the package is built, behaves at runtime, and fits the wider ecosystem. |
| `CONTRIBUTING.md` | New | Local setup and the conventions for adding components and resources. |
| `SECURITY.md` | New | Supported versions, private vulnerability reporting, and the security model. |

## Highlights

### README.md

- Added **Prerequisites** (Node.js 24, Yarn 4 via Corepack) that match what CI actually requires.
- Documented the **`.env` setup** (the dev server reads it via `dotenv-webpack`) and the local playground URL.
- Documented the **`yarn build`** and **`yarn lint`** scripts, which were previously undocumented.
- Added links to the new architecture, contributing, and security docs.

### ARCHITECTURE.md

- Explains the **ecosystem** and the boundaries between this package, `-utils`, `client-logger`, the statistics API, the docs gallery, and consuming Altinn apps (with an overview diagram).
- Describes the **runtime model** — the `init.js` bootstrap and the thin-element / fat-class render flow.
- Covers the **source layout**, the three component categories, and the conventional component-class methods.
- Documents the **resource (i18n) generation system** and app-level override behavior.
- Describes the **tag-name allow-list** security guard, the dev surfaces (DevTools / Statistics), logging, and the build/release pipeline.

### CONTRIBUTING.md

- Step-by-step local setup, including the **Gitea token** flow for the Statistics dashboard and a note that it requires the separate `altinn-studio-custom-components-api` to be running.
- A guide for **adding a new component** (element + class + tag-name allow-list + tests + docs).
- A guide for **adding/changing resources** via `resources.json` (and why the generated `resource.<lang>.json` files must not be hand-edited).
- Coding conventions, the PR checklist, and the release-triggered publish flow.

### SECURITY.md

- Points to **GitHub private vulnerability reporting** (Security tab) rather than public issues.
- Documents the **security model**: the tag-name allow-list, untrusted data sources, no-PII logging, the git-ignored Gitea token, and the fact that only `dist/` is published.

## Notes

- **No code changes** — documentation only.
- The sibling packages (`-api`, `-docs`, `-utils`) have matching documentation prepared, to be added via their own repositories.

## Checklist

- [x] Docs verified against the current code, scripts, and CI workflows
- [x] Internal cross-links between README / ARCHITECTURE / CONTRIBUTING / SECURITY resolve
- [x] No source or build changes


fixes #233 