### PR TITLE
General improvements: rendering refactor, bug fixes, and security hardening

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "jest-environment-jsdom": "^30.4.1",
         "jsdom": "^29.1.1",
         "mini-css-extract-plugin": "^2.10.2",
-        "prettier": "3.9.4",
+        "prettier": "3.9.5",
         "style-loader": "^4.0.0",
         "webpack": "^5.108.4",
         "webpack-cli": "^7.2.1",
@@ -50,7 +50,7 @@
     },
     "packageManager": "yarn@4.10.3",
     "dependencies": {
-        "@arkitektum/altinn-studio-custom-components-utils": "^1.4.15",
+        "@arkitektum/altinn-studio-custom-components-utils": "^1.5.0",
         "@arkitektum/client-logger": "^1.2.1"
     }
 }

--- a/src/classes/system-classes/component-classes/CustomMatrixData.js
+++ b/src/classes/system-classes/component-classes/CustomMatrixData.js
@@ -7,8 +7,8 @@ import CustomComponent from "../CustomComponent.js";
 // Global functions
 import { getTableHeaders, getTableRows } from "../../../functions/tableHelpers.js";
 import { hasValidationMessages, validateTableHeadersTextResourceBindings } from "../../../functions/validations.js";
+import { removeEmptyRows, sortRowsByKey as sortRows } from "../../../functions/tableDataHelpers.js";
 import { getComponentDataValue } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
 
 /**
  * CustomMatrixData is a custom component class for rendering and managing table data.
@@ -88,32 +88,8 @@ export default class CustomMatrixData extends CustomComponent {
      * @param {Array<Object>} sortedRows - The rows to be sorted.
      * @returns {Array<Object>} The sorted rows.
      */
-    sortRowsByKey(sortKey, direction, sortedRows) {
-        // Sort a shallow copy so we never mutate the underlying form data array (getComponentDataValue returns it by reference).
-        sortedRows = [...sortedRows];
-        sortedRows.sort((a, b) => {
-            let aValue = a[sortKey];
-            let bValue = b[sortKey];
-
-            const aNum = parseFloat(aValue);
-            const bNum = parseFloat(bValue);
-
-            const aIsNum = !isNaN(aNum);
-            const bIsNum = !isNaN(bNum);
-
-            if (aIsNum && bIsNum) {
-                if (aNum < bNum) return direction === "asc" ? -1 : 1;
-                if (aNum > bNum) return direction === "asc" ? 1 : -1;
-                return 0;
-            }
-
-            // fallback to string comparison
-            if (aValue < bValue) return direction === "asc" ? -1 : 1;
-            if (aValue > bValue) return direction === "asc" ? 1 : -1;
-            return 0;
-        });
-
-        return sortedRows;
+    sortRowsByKey(sortKey, direction, rows) {
+        return sortRows(sortKey, direction, rows);
     }
 
     /**
@@ -163,16 +139,7 @@ export default class CustomMatrixData extends CustomComponent {
      * @returns {Array<Array<any>>} A new array containing only the non-empty matrix rows.
      */
     removeEmptyMatrixRows(matrixRows) {
-        return Array.isArray(matrixRows)
-            ? matrixRows
-                  .map((matrixRow) => {
-                      const notEmptyMatrixCells = matrixRow.filter((matrixCell) => {
-                          return !instantiateComponent(matrixCell)?.isEmpty;
-                      });
-                      return notEmptyMatrixCells.length > 0 ? matrixRow : null;
-                  })
-                  .filter((matrixRow) => matrixRow !== null)
-            : []; // Return empty array if matrixRows is not an array
+        return removeEmptyRows(matrixRows);
     }
 
     /**

--- a/src/classes/system-classes/component-classes/CustomMatrixData.js
+++ b/src/classes/system-classes/component-classes/CustomMatrixData.js
@@ -89,6 +89,8 @@ export default class CustomMatrixData extends CustomComponent {
      * @returns {Array<Object>} The sorted rows.
      */
     sortRowsByKey(sortKey, direction, sortedRows) {
+        // Sort a shallow copy so we never mutate the underlying form data array (getComponentDataValue returns it by reference).
+        sortedRows = [...sortedRows];
         sortedRows.sort((a, b) => {
             let aValue = a[sortKey];
             let bValue = b[sortKey];
@@ -182,7 +184,9 @@ export default class CustomMatrixData extends CustomComponent {
      * @returns {boolean} Returns true if matrixRows has a value, otherwise false.
      */
     hasContent(formData) {
-        return hasValue(formData);
+        // Base emptiness on the actual rows: headers alone (an always-present array) must not count as content,
+        // otherwise a matrix whose rows are all empty renders headers instead of the empty-field text / being hidden.
+        return hasValue(formData?.matrixRows);
     }
 
     /**

--- a/src/classes/system-classes/component-classes/CustomTableData.js
+++ b/src/classes/system-classes/component-classes/CustomTableData.js
@@ -81,6 +81,8 @@ export default class CustomTableData extends CustomComponent {
     }
 
     sortRowsByKey(sortKey, direction, sortedRows) {
+        // Sort a shallow copy so we never mutate the underlying form data array (getComponentDataValue returns it by reference).
+        sortedRows = [...sortedRows];
         sortedRows.sort((a, b) => {
             let aValue = a[sortKey];
             let bValue = b[sortKey];
@@ -195,7 +197,9 @@ export default class CustomTableData extends CustomComponent {
      * @returns {boolean} Returns true if tableRows has a value, otherwise false.
      */
     hasContent(formData) {
-        return hasValue(formData);
+        // Base emptiness on the actual rows: headers alone (an always-present array) must not count as content,
+        // otherwise a table whose rows are all empty renders headers instead of the empty-field text / being hidden.
+        return hasValue(formData?.tableRows);
     }
 
     /**

--- a/src/classes/system-classes/component-classes/CustomTableData.js
+++ b/src/classes/system-classes/component-classes/CustomTableData.js
@@ -8,7 +8,7 @@ import CustomComponent from "../CustomComponent.js";
 import { getComponentDataValue, getRowNumberTitle } from "../../../functions/helpers.js";
 import { getTableHeaders, getTableRows } from "../../../functions/tableHelpers.js";
 import { hasValidationMessages, validateTableHeadersTextResourceBindings } from "../../../functions/validations.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { removeEmptyRows, sortRowsByKey as sortRows } from "../../../functions/tableDataHelpers.js";
 
 /**
  * CustomTableData is a custom component class for rendering and managing table data.
@@ -80,32 +80,8 @@ export default class CustomTableData extends CustomComponent {
         };
     }
 
-    sortRowsByKey(sortKey, direction, sortedRows) {
-        // Sort a shallow copy so we never mutate the underlying form data array (getComponentDataValue returns it by reference).
-        sortedRows = [...sortedRows];
-        sortedRows.sort((a, b) => {
-            let aValue = a[sortKey];
-            let bValue = b[sortKey];
-
-            const aNum = parseFloat(aValue);
-            const bNum = parseFloat(bValue);
-
-            const aIsNum = !isNaN(aNum);
-            const bIsNum = !isNaN(bNum);
-
-            if (aIsNum && bIsNum) {
-                if (aNum < bNum) return direction === "asc" ? -1 : 1;
-                if (aNum > bNum) return direction === "asc" ? 1 : -1;
-                return 0;
-            }
-
-            // fallback to string comparison
-            if (aValue < bValue) return direction === "asc" ? -1 : 1;
-            if (aValue > bValue) return direction === "asc" ? 1 : -1;
-            return 0;
-        });
-
-        return sortedRows;
+    sortRowsByKey(sortKey, direction, rows) {
+        return sortRows(sortKey, direction, rows);
     }
 
     /**
@@ -176,16 +152,7 @@ export default class CustomTableData extends CustomComponent {
      * @returns {Array<Array<any>>} A new array containing only the non-empty table rows.
      */
     removeEmptyTableRows(tableRows) {
-        return Array.isArray(tableRows)
-            ? tableRows
-                  .map((tableRow) => {
-                      const notEmptyTableCells = tableRow.filter((tableCell) => {
-                          return !instantiateComponent(tableCell)?.isEmpty;
-                      });
-                      return notEmptyTableCells.length > 0 ? tableRow : null;
-                  })
-                  .filter((tableRow) => tableRow !== null)
-            : []; // Return empty array if tableRows is not an array
+        return removeEmptyRows(tableRows);
     }
 
     /**

--- a/src/components/base-components/custom-feedback/index.js
+++ b/src/components/base-components/custom-feedback/index.js
@@ -1,9 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderFeedbackElement } from "./renderers.js";
@@ -15,20 +11,14 @@ export default customElements.define(
     "custom-feedback",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            const value = component?.resourceValues?.data;
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "base");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "base",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const value = component?.resourceValues?.data;
+                    host.innerHTML = renderFeedbackElement(value, component?.feedbackType);
                 }
-            } else {
-                this.innerHTML = renderFeedbackElement(value, component?.feedbackType);
-                addDevToolsOverlay(this, component, "base");
-            }
+            });
         }
     }
 );

--- a/src/components/base-components/custom-field/index.js
+++ b/src/components/base-components/custom-field/index.js
@@ -1,7 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderFieldElement } from "./renderers.js";
@@ -13,24 +11,17 @@ export default customElements.define(
     "custom-field",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "base");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "base",
+                render: (host, component) => {
+                    const options = {
+                        inline: component?.inline,
+                        styleOverride: component?.styleOverride,
+                        enableLinks: component?.enableLinks
+                    };
+                    host.innerHTML = renderFieldElement(component?.resourceValues?.title, component?.resourceValues?.data, options);
                 }
-            } else {
-                const options = {
-                    inline: component?.inline,
-                    styleOverride: component?.styleOverride,
-                    enableLinks: component?.enableLinks
-                };
-                this.innerHTML = renderFieldElement(component?.resourceValues?.title, component?.resourceValues?.data, options);
-                addDevToolsOverlay(this, component, "base");
-            }
+            });
         }
     }
 );

--- a/src/components/base-components/custom-field/renderers.js
+++ b/src/components/base-components/custom-field/renderers.js
@@ -45,9 +45,13 @@ function renderFieldValueElement(fieldValue, enableLinks) {
         fieldValue = JSON.stringify(fieldValue, null, 2);
     }
     if (!hasValue(fieldValue)) {
-        fieldValueElement.innerHTML = "";
+        fieldValueElement.textContent = "";
+    } else if (enableLinks) {
+        // injectAnchorElements returns sanitized HTML (anchors), so innerHTML is required here.
+        fieldValueElement.innerHTML = injectAnchorElements(fieldValue);
     } else {
-        fieldValueElement.innerHTML = enableLinks ? injectAnchorElements(fieldValue) : fieldValue;
+        // Plain data value: use textContent so any HTML-like content is rendered as text, not interpreted (XSS-safe).
+        fieldValueElement.textContent = fieldValue;
     }
     return fieldValueElement;
 }

--- a/src/components/base-components/custom-field/renderers.test.js
+++ b/src/components/base-components/custom-field/renderers.test.js
@@ -1,0 +1,39 @@
+import { renderFieldElement } from "./renderers";
+
+describe("renderFieldElement", () => {
+    it("renders a plain string value as text", () => {
+        const element = renderFieldElement("", "hello world", { returnHtml: false });
+        expect(element.querySelector(".field-value").textContent).toBe("hello world");
+    });
+
+    it("joins array values with a comma", () => {
+        const element = renderFieldElement("", ["a", "b", "c"], { returnHtml: false });
+        expect(element.querySelector(".field-value").textContent).toBe("a, b, c");
+    });
+
+    it("does not render HTML in the value when links are disabled (XSS-safe)", () => {
+        const payload = "<img src=x onerror=alert(1)>";
+        const element = renderFieldElement("", payload, { returnHtml: false, enableLinks: false });
+        const value = element.querySelector(".field-value");
+        // No live element was injected; the payload is shown verbatim as text.
+        expect(value.querySelector("img")).toBeNull();
+        expect(value.textContent).toBe(payload);
+    });
+
+    it("renders URLs as anchor elements when links are enabled", () => {
+        const element = renderFieldElement("", "see http://example.com", { returnHtml: false, enableLinks: true });
+        const anchor = element.querySelector(".field-value a");
+        expect(anchor).not.toBeNull();
+        expect(anchor.getAttribute("href")).toBe("http://example.com");
+    });
+
+    it("does not inject markup from a malicious URL when links are enabled", () => {
+        const element = renderFieldElement("", 'http://a.co/"><img src=x onerror=alert(1)>', { returnHtml: false, enableLinks: true });
+        expect(element.querySelector(".field-value img")).toBeNull();
+    });
+
+    it("renders an empty value as an empty field-value element", () => {
+        const element = renderFieldElement("", "", { returnHtml: false });
+        expect(element.querySelector(".field-value").textContent).toBe("");
+    });
+});

--- a/src/components/base-components/custom-matrix/index.js
+++ b/src/components/base-components/custom-matrix/index.js
@@ -1,9 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderMatrixElement } from "./renderers.js";
@@ -14,22 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-matrix",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "base");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "base",
+                render: (host, component) => {
+                    const matrixElement = renderMatrixElement(component);
+                    host.innerHTML = "";
+                    host.appendChild(matrixElement);
                 }
-            } else {
-                const matrixElement = renderMatrixElement(component);
-                this.innerHTML = "";
-                this.appendChild(matrixElement);
-                addDevToolsOverlay(this, component, "base");
-            }
+            });
         }
     }
 );

--- a/src/components/base-components/custom-matrix/renderers.js
+++ b/src/components/base-components/custom-matrix/renderers.js
@@ -14,6 +14,7 @@ import { getEmptyFieldText } from "../../../functions/helpers.js";
  */
 function renderMatrixColumnHeaderElement(matrixHeader) {
     const th = document.createElement("th");
+    th.setAttribute("scope", "col");
     th.textContent = matrixHeader.text;
     return th;
 }
@@ -29,6 +30,7 @@ function renderMatrixColumnHeaderElement(matrixHeader) {
  */
 function renderMatrixRowHeaderElement(matrixCell) {
     const th = document.createElement("th");
+    th.setAttribute("scope", "row");
     matrixCell.styleOverride = { ...matrixCell?.styleOverride, fontWeight: "var(--font-weight-bold)" };
     const htmlAttributes = new CustomElementHtmlAttributes(matrixCell);
     th.appendChild(createCustomElement(matrixCell?.tagName || "custom-field-data", htmlAttributes));

--- a/src/components/base-components/custom-matrix/renderers.js
+++ b/src/components/base-components/custom-matrix/renderers.js
@@ -31,7 +31,7 @@ function renderMatrixRowHeaderElement(matrixCell) {
     const th = document.createElement("th");
     matrixCell.styleOverride = { ...matrixCell?.styleOverride, fontWeight: "var(--font-weight-bold)" };
     const htmlAttributes = new CustomElementHtmlAttributes(matrixCell);
-    th.innerHTML = createCustomElement(matrixCell?.tagName || "custom-field-data", htmlAttributes).outerHTML;
+    th.appendChild(createCustomElement(matrixCell?.tagName || "custom-field-data", htmlAttributes));
     return th;
 }
 
@@ -44,7 +44,7 @@ function renderMatrixRowHeaderElement(matrixCell) {
 function renderMatrixCellElement(matrixCell) {
     const td = document.createElement("td");
     const htmlAttributes = new CustomElementHtmlAttributes(matrixCell);
-    td.innerHTML = createCustomElement(matrixCell?.tagName || "custom-field-data", htmlAttributes).outerHTML;
+    td.appendChild(createCustomElement(matrixCell?.tagName || "custom-field-data", htmlAttributes));
     return td;
 }
 

--- a/src/components/base-components/custom-summation/index.js
+++ b/src/components/base-components/custom-summation/index.js
@@ -2,9 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderHeaderElement, renderSummationElement } from "./renderers.js";
@@ -16,25 +14,17 @@ export default customElements.define(
     "custom-summation",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "base");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "base",
+                render: (host, component) => {
+                    const summationElement = renderSummationElement(component?.resourceValues?.data);
+                    host.innerHTML = "";
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    host.appendChild(summationElement);
                 }
-            } else {
-                const summationElement = renderSummationElement(component?.resourceValues?.data);
-                this.innerHTML = "";
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                this.appendChild(summationElement);
-                addDevToolsOverlay(this, component, "base");
-            }
+            });
         }
     }
 );

--- a/src/components/base-components/custom-table/index.js
+++ b/src/components/base-components/custom-table/index.js
@@ -1,9 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderTableElement } from "./renderers.js";
@@ -14,22 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "base");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "base",
+                render: (host, component) => {
+                    const tableElement = renderTableElement(component);
+                    host.innerHTML = "";
+                    host.appendChild(tableElement);
                 }
-            } else {
-                const tableElement = renderTableElement(component);
-                this.innerHTML = "";
-                this.appendChild(tableElement);
-                addDevToolsOverlay(this, component, "base");
-            }
+            });
         }
     }
 );

--- a/src/components/base-components/custom-table/renderers.js
+++ b/src/components/base-components/custom-table/renderers.js
@@ -43,7 +43,7 @@ function renderTableRowElement(tableRow) {
 function renderTableCellElement(tableCell) {
     const td = document.createElement("td");
     const htmlAttributes = new CustomElementHtmlAttributes(tableCell);
-    td.innerHTML = createCustomElement(tableCell?.tagName || "custom-field-data", htmlAttributes).outerHTML;
+    td.appendChild(createCustomElement(tableCell?.tagName || "custom-field-data", htmlAttributes));
     return td;
 }
 

--- a/src/components/base-components/custom-table/renderers.js
+++ b/src/components/base-components/custom-table/renderers.js
@@ -15,6 +15,7 @@ import { getEmptyFieldText } from "../../../functions/helpers.js";
  */
 function renderTableHeaderElement(tableHeader) {
     const th = document.createElement("th");
+    th.setAttribute("scope", "col");
     th.textContent = tableHeader.text;
     addStyle(th, tableHeader?.styleOverride);
     return th;

--- a/src/components/data-components/custom-description-list-data/index.js
+++ b/src/components/data-components/custom-description-list-data/index.js
@@ -22,7 +22,8 @@ export default customElements.define(
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
                 const tagName = component.isEmpty ? "custom-field" : "custom-description-list";
-                this.innerHTML = createCustomElement(tagName, htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement(tagName, htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-description-list-data/index.js
+++ b/src/components/data-components/custom-description-list-data/index.js
@@ -2,30 +2,21 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-description-list-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    const tagName = component.isEmpty ? "custom-field" : "custom-description-list";
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement(tagName, htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                const tagName = component.isEmpty ? "custom-field" : "custom-description-list";
-                this.innerHTML = "";
-                this.appendChild(createCustomElement(tagName, htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-feedback-data/index.js
+++ b/src/components/data-components/custom-feedback-data/index.js
@@ -2,29 +2,21 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-feedback-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-feedback", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-feedback", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-feedback-data/index.js
+++ b/src/components/data-components/custom-feedback-data/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-feedback", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-feedback", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-feedbacklist-data/index.js
+++ b/src/components/data-components/custom-feedbacklist-data/index.js
@@ -1,7 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderFeedbackListElement } from "./renderers.js";
@@ -13,21 +11,15 @@ export default customElements.define(
     "custom-feedbacklist-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            const feedbackMessages = component?.resourceValues?.data;
-            const title = component?.resourceValues?.title || "Messages";
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const feedbackMessages = component?.resourceValues?.data;
+                    const title = component?.resourceValues?.title || "Messages";
+                    host.innerHTML = renderFeedbackListElement(title, feedbackMessages, component?.feedbackType, component?.styleOverride);
                 }
-            } else {
-                this.innerHTML = renderFeedbackListElement(title, feedbackMessages, component?.feedbackType, component?.styleOverride);
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-feedbacklist-validation-messages/index.js
+++ b/src/components/data-components/custom-feedbacklist-validation-messages/index.js
@@ -2,9 +2,7 @@
 import ValidationMessages from "../../../classes/system-classes/ValidationMessages.js";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderValidationMessagesElement } from "./renderers.js";
@@ -16,20 +14,14 @@ export default customElements.define(
     "custom-feedbacklist-validation-messages",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            const validationMessages = new ValidationMessages(component?.resourceValues?.data);
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const validationMessages = new ValidationMessages(component?.resourceValues?.data);
+                    host.innerHTML = renderValidationMessagesElement(validationMessages);
                 }
-            } else {
-                this.innerHTML = renderValidationMessagesElement(validationMessages);
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-adresse/index.js
+++ b/src/components/data-components/custom-field-adresse/index.js
@@ -2,10 +2,7 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Stylesheet
 import "./styles.css" with { type: "css" };
@@ -14,25 +11,15 @@ export default customElements.define(
     "custom-field-adresse",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-adresse/index.js
+++ b/src/components/data-components/custom-field-adresse/index.js
@@ -25,7 +25,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
             const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);

--- a/src/components/data-components/custom-field-boolean-data/index.js
+++ b/src/components/data-components/custom-field-boolean-data/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-boolean-data",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-boolean-data/index.js
+++ b/src/components/data-components/custom-field-boolean-data/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-boolean-text/index.js
+++ b/src/components/data-components/custom-field-boolean-text/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-boolean-text/index.js
+++ b/src/components/data-components/custom-field-boolean-text/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-boolean-text",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-count-data/index.js
+++ b/src/components/data-components/custom-field-count-data/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-count-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-count-data/index.js
+++ b/src/components/data-components/custom-field-count-data/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-data/index.js
+++ b/src/components/data-components/custom-field-data/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-data/index.js
+++ b/src/components/data-components/custom-field-data/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-grid/index.js
+++ b/src/components/data-components/custom-field-grid/index.js
@@ -1,9 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderFieldGridElement } from "./renderers.js";
@@ -15,20 +11,10 @@ export default customElements.define(
     "custom-field-grid",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else {
-                const gridElement = renderFieldGridElement(component);
-                this.appendChild(gridElement);
-                addDevToolsOverlay(this, component, "data");
-            }
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => host.appendChild(renderFieldGridElement(component))
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-image/index.js
+++ b/src/components/data-components/custom-field-image/index.js
@@ -1,9 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderImageElement } from "./renderers.js";
@@ -15,20 +11,10 @@ export default customElements.define(
     "custom-field-image",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else {
-                const imageElement = renderImageElement(component);
-                this.appendChild(imageElement);
-                addDevToolsOverlay(this, component, "data");
-            }
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => host.appendChild(renderImageElement(component))
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-kode/index.js
+++ b/src/components/data-components/custom-field-kode/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-kode",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-kode/index.js
+++ b/src/components/data-components/custom-field-kode/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-kommunens-saksnummer/index.js
+++ b/src/components/data-components/custom-field-kommunens-saksnummer/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-kommunens-saksnummer/index.js
+++ b/src/components/data-components/custom-field-kommunens-saksnummer/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-kommunens-saksnummer",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-list-data/index.js
+++ b/src/components/data-components/custom-field-list-data/index.js
@@ -19,7 +19,8 @@ export default customElements.define(
                 }
             } else {
                 const fieldListDataElement = renderListFieldElement(component);
-                this.innerHTML = fieldListDataElement.outerHTML;
+                this.innerHTML = "";
+                this.appendChild(fieldListDataElement);
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-list-data/index.js
+++ b/src/components/data-components/custom-field-list-data/index.js
@@ -1,28 +1,21 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
+
+// Local functions
 import { renderListFieldElement } from "./renderers.js";
 
 export default customElements.define(
     "custom-field-list-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const fieldListDataElement = renderListFieldElement(component);
+                    host.innerHTML = "";
+                    host.appendChild(fieldListDataElement);
                 }
-            } else {
-                const fieldListDataElement = renderListFieldElement(component);
-                this.innerHTML = "";
-                this.appendChild(fieldListDataElement);
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-part-navn/index.js
+++ b/src/components/data-components/custom-field-part-navn/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-part-navn",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-part-navn/index.js
+++ b/src/components/data-components/custom-field-part-navn/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-prosjekt/index.js
+++ b/src/components/data-components/custom-field-prosjekt/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-prosjekt",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-prosjekt/index.js
+++ b/src/components/data-components/custom-field-prosjekt/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-row/index.js
+++ b/src/components/data-components/custom-field-row/index.js
@@ -1,9 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderFieldRowElement } from "./renderers.js";
@@ -15,20 +11,10 @@ export default customElements.define(
     "custom-field-row",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else {
-                const rowElement = renderFieldRowElement(component);
-                this.appendChild(rowElement);
-                addDevToolsOverlay(this, component, "data");
-            }
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => host.appendChild(renderFieldRowElement(component))
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-telefonnummer/index.js
+++ b/src/components/data-components/custom-field-telefonnummer/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-field-telefonnummer/index.js
+++ b/src/components/data-components/custom-field-telefonnummer/index.js
@@ -2,29 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-telefonnummer",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-field-utfall-svar-status/index.js
+++ b/src/components/data-components/custom-field-utfall-svar-status/index.js
@@ -22,7 +22,8 @@ export default customElements.define(
                 }
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
             const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);

--- a/src/components/data-components/custom-field-utfall-svar-status/index.js
+++ b/src/components/data-components/custom-field-utfall-svar-status/index.js
@@ -2,34 +2,21 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-field-utfall-svar-status",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement("custom-field", htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-adkomst/index.js
+++ b/src/components/data-components/custom-group-adkomst/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderErNyEllerEndretAdkomstElement, renderHeaderElement, renderVegtypeTillatelseElement } from "./renderers.js";
@@ -13,33 +10,23 @@ import { renderEmptyFieldText, renderErNyEllerEndretAdkomstElement, renderHeader
 export default customElements.define(
     "custom-group-adkomst",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderErNyEllerEndretAdkomstElement(component));
+                        host.appendChild(renderVegtypeTillatelseElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderErNyEllerEndretAdkomstElement(component));
-                    this.appendChild(renderVegtypeTillatelseElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-ansvarsrett-erklaeringer/index.js
+++ b/src/components/data-components/custom-group-ansvarsrett-erklaeringer/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -21,49 +18,39 @@ import {
 export default customElements.define(
     "custom-group-ansvarsrett-erklaeringer",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            let funksjonList = [];
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else {
-                if (hasValue(component?.resourceBindings?.erklaeringer?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceBindings?.erklaeringer?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    component.resourceValues?.data?.forEach((element) => {
-                        funksjonList.push(element.funksjon?.kodeverdi?.toUpperCase());
-                    });
-
-                    this.appendChild(renderErklaeringTekstElement(component));
-
-                    this.appendChild(renderSOEKTekstElement(component));
-
-                    if (funksjonList.includes("PRO")) {
-                        this.appendChild(renderPROTekstElement(component));
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    let funksjonList = [];
+                    if (hasValue(component?.resourceBindings?.erklaeringer?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceBindings?.erklaeringer?.title, component?.size));
                     }
-                    if (funksjonList.includes("UTF")) {
-                        this.appendChild(renderUTFTekstElement(component));
-                    }
-                    if (funksjonList.includes("KONTROLL")) {
-                        this.appendChild(renderKONTROLLTekstElement(component));
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        component.resourceValues?.data?.forEach((element) => {
+                            funksjonList.push(element.funksjon?.kodeverdi?.toUpperCase());
+                        });
+
+                        host.appendChild(renderErklaeringTekstElement(component));
+
+                        host.appendChild(renderSOEKTekstElement(component));
+
+                        if (funksjonList.includes("PRO")) {
+                            host.appendChild(renderPROTekstElement(component));
+                        }
+                        if (funksjonList.includes("UTF")) {
+                            host.appendChild(renderUTFTekstElement(component));
+                        }
+                        if (funksjonList.includes("KONTROLL")) {
+                            host.appendChild(renderKONTROLLTekstElement(component));
+                        }
                     }
                 }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-avloep/index.js
+++ b/src/components/data-components/custom-group-avloep/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -21,36 +18,26 @@ import {
 export default customElements.define(
     "custom-group-avloep",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderTilknytningstypeElement(component));
+                        host.appendChild(renderSkalInstallereVannklosettElement(component));
+                        host.appendChild(renderHarUtslippstillatelseElement(component));
+                        host.appendChild(renderKrysserAvloepAnnensGrunnElement(component));
+                        host.appendChild(renderHarTinglystErklaeringElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderTilknytningstypeElement(component));
-                    this.appendChild(renderSkalInstallereVannklosettElement(component));
-                    this.appendChild(renderHarUtslippstillatelseElement(component));
-                    this.appendChild(renderKrysserAvloepAnnensGrunnElement(component));
-                    this.appendChild(renderHarTinglystErklaeringElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-dispensasjon-oversikt/index.js
+++ b/src/components/data-components/custom-group-dispensasjon-oversikt/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderDispensasjonCount, renderDispensasjonTable, renderEmptyFieldText, renderHeaderElement } from "./renderers.js";
@@ -16,33 +13,23 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-group-dispensasjon-oversikt",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderDispensasjonCount(component));
+                        host.appendChild(renderDispensasjonTable(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderDispensasjonCount(component));
-                    this.appendChild(renderDispensasjonTable(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-kontroll-ansvarsomraade/index.js
+++ b/src/components/data-components/custom-group-kontroll-ansvarsomraade/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -18,40 +15,31 @@ import {
 export default customElements.define(
     "custom-group-kontroll-ansvarsomraade",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const containerElement = document.createElement("div");
+
+                        containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.ansvarsomraade?.title, component?.size));
+
+                        containerElement.appendChild(renderFunksjonElement(component));
+                        containerElement.appendChild(renderBeskrivelseElement(component));
+                        containerElement.appendChild(renderAnsvarsrettErklaertElement(component));
+                        containerElement.appendChild(renderArbeidetAvsluttetElement(component));
+
+                        containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.sluttrapport?.title, component?.size));
+                        containerElement.appendChild(renderFunnetAvvikElement(component));
+
+                        host.appendChild(containerElement);
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const containerElement = document.createElement("div");
-
-                containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.ansvarsomraade?.title, component?.size));
-
-                containerElement.appendChild(renderFunksjonElement(component));
-                containerElement.appendChild(renderBeskrivelseElement(component));
-                containerElement.appendChild(renderAnsvarsrettErklaertElement(component));
-                containerElement.appendChild(renderArbeidetAvsluttetElement(component));
-
-                containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.sluttrapport?.title, component?.size));
-                containerElement.appendChild(renderFunnetAvvikElement(component));
-
-                this.appendChild(containerElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-kontroll-erklaeringer/index.js
+++ b/src/components/data-components/custom-group-kontroll-erklaeringer/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderErklaeringTekstElement, renderHeaderElement, renderKONTROLLTekstElement } from "./renderers.js";
@@ -13,37 +10,27 @@ import { renderEmptyFieldText, renderErklaeringTekstElement, renderHeaderElement
 export default customElements.define(
     "custom-group-kontroll-erklaeringer",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else {
-                if (hasValue(component?.resourceBindings?.erklaeringer?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceBindings?.erklaeringer?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderErklaeringTekstElement(component));
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceBindings?.erklaeringer?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceBindings?.erklaeringer?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderErklaeringTekstElement(component));
 
-                    let funksjon = component.resourceValues?.data?.funksjon?.kodeverdi?.toUpperCase();
-                    if (funksjon === "KONTROLL") {
-                        this.appendChild(renderKONTROLLTekstElement(component));
+                        let funksjon = component.resourceValues?.data?.funksjon?.kodeverdi?.toUpperCase();
+                        if (funksjon === "KONTROLL") {
+                            host.appendChild(renderKONTROLLTekstElement(component));
+                        }
                     }
                 }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-loefteinnretninger/index.js
+++ b/src/components/data-components/custom-group-loefteinnretninger/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -19,34 +16,24 @@ import {
 export default customElements.define(
     "custom-group-loefteinnretninger",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderErLoefteinnretningIBygningElement(component));
+                        host.appendChild(renderPlanleggesLoefteinnretningIBygningElement(component));
+                        host.appendChild(renderPlanlagteLoefteinnretningerElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderErLoefteinnretningIBygningElement(component));
-                    this.appendChild(renderPlanleggesLoefteinnretningIBygningElement(component));
-                    this.appendChild(renderPlanlagteLoefteinnretningerElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-overvann/index.js
+++ b/src/components/data-components/custom-group-overvann/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -18,33 +15,23 @@ import {
 export default customElements.define(
     "custom-group-overvann",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderLedesOvervannTilTerrengElement(component));
+                        host.appendChild(renderLedesOvervannTilAvloepssystemElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderLedesOvervannTilTerrengElement(component));
-                    this.appendChild(renderLedesOvervannTilAvloepssystemElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-rammebetingelser-krav-til-byggegrunn/index.js
+++ b/src/components/data-components/custom-group-rammebetingelser-krav-til-byggegrunn/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHarMiljoeforholdElement, renderHeaderElement, renderOmraaderisiko } from "./renderers.js";
@@ -13,33 +10,23 @@ import { renderEmptyFieldText, renderHarMiljoeforholdElement, renderHeaderElemen
 export default customElements.define(
     "custom-group-rammebetingelser-krav-til-byggegrunn",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderOmraaderisiko(component));
+                        host.appendChild(renderHarMiljoeforholdElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderOmraaderisiko(component));
-                    this.appendChild(renderHarMiljoeforholdElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-rammebetingelser-tilknytninger/index.js
+++ b/src/components/data-components/custom-group-rammebetingelser-tilknytninger/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -20,35 +17,25 @@ import {
 export default customElements.define(
     "custom-group-rammebetingelser-tilknytninger",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderAdkomstElement(component));
+                        host.appendChild(renderVannforsyningElement(component));
+                        host.appendChild(renderAvloepElement(component));
+                        host.appendChild(renderOvervannElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderAdkomstElement(component));
-                    this.appendChild(renderVannforsyningElement(component));
-                    this.appendChild(renderAvloepElement(component));
-                    this.appendChild(renderOvervannElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-samsvar-erklaeringer/index.js
+++ b/src/components/data-components/custom-group-samsvar-erklaeringer/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -19,43 +16,33 @@ import {
 export default customElements.define(
     "custom-group-samsvar-erklaeringer",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            let funksjonList = [];
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else {
-                if (hasValue(component?.resourceBindings?.erklaeringer?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceBindings?.erklaeringer?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    component.resourceValues?.data?.forEach((element) => {
-                        funksjonList.push(element.funksjon?.kodeverdi?.toUpperCase());
-                    });
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    let funksjonList = [];
+                    if (hasValue(component?.resourceBindings?.erklaeringer?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceBindings?.erklaeringer?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        component.resourceValues?.data?.forEach((element) => {
+                            funksjonList.push(element.funksjon?.kodeverdi?.toUpperCase());
+                        });
 
-                    this.appendChild(renderErklaeringTekstElement(component));
-                    if (funksjonList.includes("PRO")) {
-                        this.appendChild(renderPROTekstElement(component));
-                    }
-                    if (funksjonList.includes("UTF")) {
-                        this.appendChild(renderUTFTekstElement(component));
+                        host.appendChild(renderErklaeringTekstElement(component));
+                        if (funksjonList.includes("PRO")) {
+                            host.appendChild(renderPROTekstElement(component));
+                        }
+                        if (funksjonList.includes("UTF")) {
+                            host.appendChild(renderUTFTekstElement(component));
+                        }
                     }
                 }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-group-vannforsyning/index.js
+++ b/src/components/data-components/custom-group-vannforsyning/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -20,35 +17,25 @@ import {
 export default customElements.define(
     "custom-group-vannforsyning",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                        host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                    }
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderTilknytningstypeElement(component));
+                        host.appendChild(renderBeskrivelseElement(component));
+                        host.appendChild(renderKrysserVannforsyningAnnensGrunnElement(component));
+                        host.appendChild(renderHarTinglystErklaeringElement(component));
+                    }
                 }
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                if (component?.isEmpty) {
-                    const emptyFieldTextElement = renderEmptyFieldText(component);
-                    this.appendChild(emptyFieldTextElement);
-                } else {
-                    this.appendChild(renderTilknytningstypeElement(component));
-                    this.appendChild(renderBeskrivelseElement(component));
-                    this.appendChild(renderKrysserVannforsyningAnnensGrunnElement(component));
-                    this.appendChild(renderHarTinglystErklaeringElement(component));
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js
+++ b/src/components/data-components/custom-grouplist-ettersending/custom-group-ettersending/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHeaderElement, renderKommentarElement, renderTemaElement, renderVedleggslisteElement } from "./renderers.js";
@@ -13,35 +10,26 @@ import { renderEmptyFieldText, renderHeaderElement, renderKommentarElement, rend
 export default customElements.define(
     "custom-group-ettersending",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const containerElement = document.createElement("div");
+                        if (hasValue(component?.resourceValues?.data?.tittel) && component?.hideTitle !== true) {
+                            containerElement.appendChild(renderHeaderElement(component?.resourceValues?.data?.tittel, component?.size));
+                        }
+                        containerElement.appendChild(renderTemaElement(component));
+                        containerElement.appendChild(renderKommentarElement(component));
+                        containerElement.appendChild(renderVedleggslisteElement(component));
+                        host.appendChild(containerElement);
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const containerElement = document.createElement("div");
-                if (hasValue(component?.resourceValues?.data?.tittel) && component?.hideTitle !== true) {
-                    containerElement.appendChild(renderHeaderElement(component?.resourceValues?.data?.tittel, component?.size));
-                }
-                containerElement.appendChild(renderTemaElement(component));
-                containerElement.appendChild(renderKommentarElement(component));
-                containerElement.appendChild(renderVedleggslisteElement(component));
-                this.appendChild(containerElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-ettersending/index.js
+++ b/src/components/data-components/custom-grouplist-ettersending/index.js
@@ -2,10 +2,7 @@
 import { createCustomElement, hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderEttersendingGroup, renderHeaderElement } from "./renderers.js";
@@ -14,35 +11,26 @@ export default customElements.define(
     "custom-grouplist-ettersending",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                            host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                        }
+                        for (const ettersending of component?.resourceValues?.data ?? []) {
+                            const ettersendingElement = renderEttersendingGroup(ettersending, component);
+                            host.appendChild(ettersendingElement);
+                            const dividerElement = createCustomElement("custom-divider");
+                            host.appendChild(dividerElement);
+                        }
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                for (const ettersending of component?.resourceValues?.data ?? []) {
-                    const ettersendingElement = renderEttersendingGroup(ettersending, component);
-                    this.appendChild(ettersendingElement);
-                    const dividerElement = createCustomElement("custom-divider");
-                    this.appendChild(dividerElement);
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-nabo-gjenboer-eiendom/custom-group-nabo-gjenboer-eiendom/index.js
+++ b/src/components/data-components/custom-grouplist-nabo-gjenboer-eiendom/custom-group-nabo-gjenboer-eiendom/index.js
@@ -1,7 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../../functions/componentRenderHelpers.js";
 import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
 
 // Local functions
@@ -19,37 +17,33 @@ import {
 export default customElements.define(
     "custom-group-nabo-gjenboer-eiendom",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const containerElement = document.createElement("div");
-                containerElement.appendChild(renderNaboGjenboerEiendomElement(component));
-                containerElement.appendChild(renderEierPartElement(component));
-                containerElement.appendChild(renderEierAdresseElement(component));
-                containerElement.appendChild(renderResponsNabovarselSendtViaElement(component));
-                containerElement.appendChild(renderResponsNabovarselSendtElement(component));
-                containerElement.appendChild(renderResponsErMerknadEllerSamtykkeMottattElement(component));
-                containerElement.appendChild(renderResponsSamtykkeEllerMerknadMottattElement(component));
-                this.appendChild(containerElement);
+        connectedCallback() {
+            // Feedback is appended only in the non-empty branch (matching the original), so it is handled inside
+            // render rather than via the helper's withFeedback option.
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const containerElement = document.createElement("div");
+                        containerElement.appendChild(renderNaboGjenboerEiendomElement(component));
+                        containerElement.appendChild(renderEierPartElement(component));
+                        containerElement.appendChild(renderEierAdresseElement(component));
+                        containerElement.appendChild(renderResponsNabovarselSendtViaElement(component));
+                        containerElement.appendChild(renderResponsNabovarselSendtElement(component));
+                        containerElement.appendChild(renderResponsErMerknadEllerSamtykkeMottattElement(component));
+                        containerElement.appendChild(renderResponsSamtykkeEllerMerknadMottattElement(component));
+                        host.appendChild(containerElement);
 
-                const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-                if (feedbackListElement) {
-                    this.appendChild(feedbackListElement);
+                        const feedbackListElement = component.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
+                        if (feedbackListElement) {
+                            host.appendChild(feedbackListElement);
+                        }
+                    }
                 }
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-samsvar-ansvarsomraade/custom-group-samsvar-ansvarsomraade/index.js
+++ b/src/components/data-components/custom-grouplist-samsvar-ansvarsomraade/custom-group-samsvar-ansvarsomraade/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -27,64 +24,55 @@ import {
 export default customElements.define(
     "custom-group-samsvar-ansvarsomraade",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const funksjonKodeverdi = component.resourceValues?.data?.funksjon?.kodeverdi?.toUpperCase();
-                const containerElement = document.createElement("div");
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const funksjonKodeverdi = component.resourceValues?.data?.funksjon?.kodeverdi?.toUpperCase();
+                        const containerElement = document.createElement("div");
 
-                containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.ansvarsomraade?.title, component?.size));
+                        containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.ansvarsomraade?.title, component?.size));
 
-                containerElement.appendChild(renderFunksjonElement(component));
-                containerElement.appendChild(renderBeskrivelseElement(component));
-                containerElement.appendChild(renderAnsvarsrettErklaertElement(component));
-                containerElement.appendChild(renderArbeidetAvsluttetElement(component));
-                if (funksjonKodeverdi === "PRO") {
-                    containerElement.appendChild(renderAvdekketGjenstaaendePROElement(component));
-                }
+                        containerElement.appendChild(renderFunksjonElement(component));
+                        containerElement.appendChild(renderBeskrivelseElement(component));
+                        containerElement.appendChild(renderAnsvarsrettErklaertElement(component));
+                        containerElement.appendChild(renderArbeidetAvsluttetElement(component));
+                        if (funksjonKodeverdi === "PRO") {
+                            containerElement.appendChild(renderAvdekketGjenstaaendePROElement(component));
+                        }
 
-                if (funksjonKodeverdi === "UTF") {
-                    containerElement.appendChild(renderAvdekketGjenstaaendeUTFElement(component));
-                }
-                if (
-                    funksjonKodeverdi === "UTF" &&
-                    component?.resourceValues?.data?.utfoerende?.midlertidigBrukstillatelse?.erOkForMidlertidigBrukstillatelse === true &&
-                    hasValue(component?.resourceValues?.data?.utfoerende?.midlertidigBrukstillatelse?.gjenstaaendeArbeider)
-                ) {
-                    containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.gjenstaaendeArbeider?.title, component?.size));
+                        if (funksjonKodeverdi === "UTF") {
+                            containerElement.appendChild(renderAvdekketGjenstaaendeUTFElement(component));
+                        }
+                        if (
+                            funksjonKodeverdi === "UTF" &&
+                            component?.resourceValues?.data?.utfoerende?.midlertidigBrukstillatelse?.erOkForMidlertidigBrukstillatelse === true &&
+                            hasValue(component?.resourceValues?.data?.utfoerende?.midlertidigBrukstillatelse?.gjenstaaendeArbeider)
+                        ) {
+                            containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.gjenstaaendeArbeider?.title, component?.size));
 
-                    containerElement.appendChild(renderGjenstaaendeArbeiderInnenforElement(component));
-                    containerElement.appendChild(renderGjenstaaendeArbeiderUtenforElement(component));
+                            containerElement.appendChild(renderGjenstaaendeArbeiderInnenforElement(component));
+                            containerElement.appendChild(renderGjenstaaendeArbeiderUtenforElement(component));
 
-                    containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.sikkerhetsNivaa?.title, component?.size));
+                            containerElement.appendChild(renderHeaderElement(component?.resourceBindings?.sikkerhetsNivaa?.title, component?.size));
 
-                    containerElement.appendChild(renderTilstrekkeligSikkerhetElement(component));
+                            containerElement.appendChild(renderTilstrekkeligSikkerhetElement(component));
 
-                    if (component?.resourceValues?.data?.utfoerende?.midlertidigBrukstillatelse?.sikkerhet?.harTilstrekkeligSikkerhet === false) {
-                        containerElement.appendChild(renderUtfoereInnenElement(component));
-                        containerElement.appendChild(renderTypeArbeiderElement(component));
+                            if (component?.resourceValues?.data?.utfoerende?.midlertidigBrukstillatelse?.sikkerhet?.harTilstrekkeligSikkerhet === false) {
+                                containerElement.appendChild(renderUtfoereInnenElement(component));
+                                containerElement.appendChild(renderTypeArbeiderElement(component));
+                            }
+                        }
+
+                        host.appendChild(containerElement);
                     }
                 }
-
-                this.appendChild(containerElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-samsvar-ansvarsomraade/index.js
+++ b/src/components/data-components/custom-grouplist-samsvar-ansvarsomraade/index.js
@@ -2,10 +2,7 @@
 import { createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderSamsvarAnsvarsomraadeGroup } from "./renderers.js";
@@ -14,42 +11,33 @@ export default customElements.define(
     "custom-grouplist-samsvar-ansvarsomraade",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const data = component?.resourceValues?.data ?? [];
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const data = component?.resourceValues?.data ?? [];
 
-                data.sort((a, b) => {
-                    const aCode = a?.funksjon?.kodeverdi?.toUpperCase();
-                    const bCode = b?.funksjon?.kodeverdi?.toUpperCase();
+                        data.sort((a, b) => {
+                            const aCode = a?.funksjon?.kodeverdi?.toUpperCase();
+                            const bCode = b?.funksjon?.kodeverdi?.toUpperCase();
 
-                    if (aCode === "PRO" && bCode !== "PRO") return -1;
-                    if (aCode !== "PRO" && bCode === "PRO") return 1;
-                    return 0;
-                });
-                for (const samsvarAnsvarsomraade of data) {
-                    const samsvarAnsvarsomraadeElement = renderSamsvarAnsvarsomraadeGroup(samsvarAnsvarsomraade, component);
-                    this.appendChild(samsvarAnsvarsomraadeElement);
-                    const dividerElement = createCustomElement("custom-divider");
-                    this.appendChild(dividerElement);
+                            if (aCode === "PRO" && bCode !== "PRO") return -1;
+                            if (aCode !== "PRO" && bCode === "PRO") return 1;
+                            return 0;
+                        });
+                        for (const samsvarAnsvarsomraade of data) {
+                            const samsvarAnsvarsomraadeElement = renderSamsvarAnsvarsomraadeGroup(samsvarAnsvarsomraade, component);
+                            host.appendChild(samsvarAnsvarsomraadeElement);
+                            const dividerElement = createCustomElement("custom-divider");
+                            host.appendChild(dividerElement);
+                        }
+                    }
                 }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHeaderElement, renderSjekklistepunk } from "./renderers.js";
@@ -16,33 +13,24 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-group-sjekklistekrav",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const containerElement = document.createElement("div");
+                        if (hasValue(component?.resourceValues?.data?.tittel) && component?.hideTitle !== true) {
+                            containerElement.appendChild(renderHeaderElement(component?.resourceValues?.data?.tittel, component?.size));
+                        }
+                        containerElement.appendChild(renderSjekklistepunk(component));
+                        host.appendChild(containerElement);
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const containerElement = document.createElement("div");
-                if (hasValue(component?.resourceValues?.data?.tittel) && component?.hideTitle !== true) {
-                    containerElement.appendChild(renderHeaderElement(component?.resourceValues?.data?.tittel, component?.size));
-                }
-                containerElement.appendChild(renderSjekklistepunk(component));
-                this.appendChild(containerElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-sjekklistekrav/index.js
+++ b/src/components/data-components/custom-grouplist-sjekklistekrav/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -24,53 +21,44 @@ export default customElements.define(
     "custom-grouplist-sjekklistekrav",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
-                }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                const sjekklistekravListElement = document.createElement("div");
-                sjekklistekravListElement.className = "sjekklistekrav-list";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                            host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                        }
+                        const sjekklistekravListElement = document.createElement("div");
+                        sjekklistekravListElement.className = "sjekklistekrav-list";
 
-                const sjekklistekravGroupListHeaderElement = renderSjekklistekravGroupListHeader(component);
-                if (sjekklistekravGroupListHeaderElement) {
-                    sjekklistekravListElement.appendChild(sjekklistekravGroupListHeaderElement);
-                }
-                for (const sjekklistekrav of component?.resourceValues?.data ?? []) {
-                    const sjekklistekravElement = renderSjekklistekravGroup(sjekklistekrav, component);
-                    sjekklistekravListElement.appendChild(sjekklistekravElement);
-                    const dividerElement = renderDivider();
-                    sjekklistekravListElement.appendChild(dividerElement);
-                }
-                this.appendChild(sjekklistekravListElement);
+                        const sjekklistekravGroupListHeaderElement = renderSjekklistekravGroupListHeader(component);
+                        if (sjekklistekravGroupListHeaderElement) {
+                            sjekklistekravListElement.appendChild(sjekklistekravGroupListHeaderElement);
+                        }
+                        for (const sjekklistekrav of component?.resourceValues?.data ?? []) {
+                            const sjekklistekravElement = renderSjekklistekravGroup(sjekklistekrav, component);
+                            sjekklistekravListElement.appendChild(sjekklistekravElement);
+                            const dividerElement = renderDivider();
+                            sjekklistekravListElement.appendChild(dividerElement);
+                        }
+                        host.appendChild(sjekklistekravListElement);
 
-                // Remove the last divider
-                if (sjekklistekravListElement.lastChild) {
-                    sjekklistekravListElement.removeChild(sjekklistekravListElement.lastChild);
-                }
+                        // Remove the last divider
+                        if (sjekklistekravListElement.lastChild) {
+                            sjekklistekravListElement.removeChild(sjekklistekravListElement.lastChild);
+                        }
 
-                if (hasValue(component?.resourceValues?.description)) {
-                    const descriptionElement = renderDescription(component);
-                    this.appendChild(descriptionElement);
+                        if (hasValue(component?.resourceValues?.description)) {
+                            const descriptionElement = renderDescription(component);
+                            host.appendChild(descriptionElement);
+                        }
+                    }
                 }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/custom-group-utfall-svar/index.js
@@ -2,10 +2,7 @@
 import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import {
@@ -20,33 +17,23 @@ import {
 export default customElements.define(
     "custom-group-utfall-svar",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const containerElement = document.createElement("div");
+                    if (hasValue(component?.resourceValues?.data?.tittel) && component?.hideTitle !== true) {
+                        containerElement.appendChild(renderHeaderElement(component?.resourceValues?.data?.tittel, component?.size));
+                    }
+                    containerElement.appendChild(renderBeskrivelseElement(component));
+                    containerElement.appendChild(renderStatusElement(component));
+                    containerElement.appendChild(renderTemaElement(component));
+                    containerElement.appendChild(renderKommentarElement(component));
+                    containerElement.appendChild(renderVedleggslisteElement(component));
+                    host.appendChild(containerElement);
                 }
-            } else {
-                const containerElement = document.createElement("div");
-                if (hasValue(component?.resourceValues?.data?.tittel) && component?.hideTitle !== true) {
-                    containerElement.appendChild(renderHeaderElement(component?.resourceValues?.data?.tittel, component?.size));
-                }
-                containerElement.appendChild(renderBeskrivelseElement(component));
-                containerElement.appendChild(renderStatusElement(component));
-                containerElement.appendChild(renderTemaElement(component));
-                containerElement.appendChild(renderKommentarElement(component));
-                containerElement.appendChild(renderVedleggslisteElement(component));
-                this.appendChild(containerElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/custom-grouplist-utfall-svar/index.js
@@ -2,10 +2,7 @@
 import { createCustomElement, hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHeaderElement, renderUtfallSvarGroup } from "./renderers.js";
@@ -14,35 +11,26 @@ export default customElements.define(
     "custom-grouplist-utfall-svar",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
+                            host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                        }
+                        for (const utfallSvar of component?.resourceValues?.data ?? []) {
+                            const utfallSvarElement = renderUtfallSvarGroup(utfallSvar, component);
+                            host.appendChild(utfallSvarElement);
+                            const dividerElement = createCustomElement("custom-divider");
+                            host.appendChild(dividerElement);
+                        }
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                if (hasValue(component?.resourceValues?.title) && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                for (const utfallSvar of component?.resourceValues?.data ?? []) {
-                    const utfallSvarElement = renderUtfallSvarGroup(utfallSvar, component);
-                    this.appendChild(utfallSvarElement);
-                    const dividerElement = createCustomElement("custom-divider");
-                    this.appendChild(dividerElement);
-                }
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/index.js
+++ b/src/components/data-components/custom-grouplist-utfall-svar-type/custom-group-utfall-svar-type/index.js
@@ -1,9 +1,6 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../../functions/componentRenderHelpers.js";
 import { renderEmptyFieldText } from "../../custom-grouplist-sjekklistekrav/custom-group-sjekklistekrav/renderers.js";
-import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
 
 // Local functions
 import { renderUtfallSvarGroupList } from "./renderers.js";
@@ -11,29 +8,20 @@ import { renderUtfallSvarGroupList } from "./renderers.js";
 export default customElements.define(
     "custom-group-utfall-svar-type",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const utfallSvarGroupListElement = renderUtfallSvarGroupList(component);
+                        host.appendChild(utfallSvarGroupListElement);
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const utfallSvarGroupListElement = renderUtfallSvarGroupList(component);
-                this.appendChild(utfallSvarGroupListElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-grouplist-vegtype-tillatelse/custom-group-vegtype-tillatelse/index.js
+++ b/src/components/data-components/custom-grouplist-vegtype-tillatelse/custom-group-vegtype-tillatelse/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../../functions/helpers.js";
-import { instantiateComponent } from "../../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderErTillatelseGittElement, renderVegtypeElement } from "./renderers.js";
@@ -10,29 +7,20 @@ import { renderEmptyFieldText, renderErTillatelseGittElement, renderVegtypeEleme
 export default customElements.define(
     "custom-group-vegtype-tillatelse",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        host.appendChild(renderVegtypeElement(component));
+                        host.appendChild(renderErTillatelseGittElement(component));
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                this.appendChild(renderVegtypeElement(component));
-                this.appendChild(renderErTillatelseGittElement(component));
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-header-text-data/index.js
+++ b/src/components/data-components/custom-header-text-data/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 });
             }
             const htmlAttributes = new CustomElementHtmlAttributes(component);
-            this.innerHTML = createCustomElement("custom-header", htmlAttributes).outerHTML;
+            this.innerHTML = "";
+            this.appendChild(createCustomElement("custom-header", htmlAttributes));
             addDevToolsOverlay(this, component, "data");
         }
     }

--- a/src/components/data-components/custom-header-text/index.js
+++ b/src/components/data-components/custom-header-text/index.js
@@ -21,7 +21,8 @@ export default customElements.define(
                 });
             }
             const htmlAttributes = new CustomElementHtmlAttributes(component);
-            this.innerHTML = createCustomElement("custom-header", htmlAttributes).outerHTML;
+            this.innerHTML = "";
+            this.appendChild(createCustomElement("custom-header", htmlAttributes));
             addDevToolsOverlay(this, component, "data");
         }
     }

--- a/src/components/data-components/custom-list-data/index.js
+++ b/src/components/data-components/custom-list-data/index.js
@@ -22,7 +22,8 @@ export default customElements.define(
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
                 const tagName = component.isEmpty ? "custom-field" : "custom-list";
-                this.innerHTML = createCustomElement(tagName, htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement(tagName, htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-list-data/index.js
+++ b/src/components/data-components/custom-list-data/index.js
@@ -2,30 +2,21 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-list-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    const tagName = component.isEmpty ? "custom-field" : "custom-list";
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement(tagName, htmlAttributes));
                 }
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                const tagName = component.isEmpty ? "custom-field" : "custom-list";
-                this.innerHTML = "";
-                this.appendChild(createCustomElement(tagName, htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-list-planlagte-loefteinnretninger/index.js
+++ b/src/components/data-components/custom-list-planlagte-loefteinnretninger/index.js
@@ -25,7 +25,8 @@ export default customElements.define(
                 }
             } else if (component?.isEmpty) {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             } else {
                 const planlagteLoefteinnretningerListElement = renderPlanlagteLoefteinnretningerList(component);

--- a/src/components/data-components/custom-list-planlagte-loefteinnretninger/index.js
+++ b/src/components/data-components/custom-list-planlagte-loefteinnretninger/index.js
@@ -2,10 +2,7 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderPlanlagteLoefteinnretningerList } from "./renderers.js";
@@ -14,29 +11,20 @@ export default customElements.define(
     "custom-list-planlagte-loefteinnretninger",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const htmlAttributes = new CustomElementHtmlAttributes(component);
+                        host.innerHTML = "";
+                        host.appendChild(createCustomElement("custom-field", htmlAttributes));
+                    } else {
+                        const planlagteLoefteinnretningerListElement = renderPlanlagteLoefteinnretningerList(component);
+                        host.appendChild(planlagteLoefteinnretningerListElement);
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const planlagteLoefteinnretningerListElement = renderPlanlagteLoefteinnretningerList(component);
-                this.appendChild(planlagteLoefteinnretningerListElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-list-vedlegg/index.js
+++ b/src/components/data-components/custom-list-vedlegg/index.js
@@ -2,34 +2,20 @@
 import { CustomElementHtmlAttributes, createCustomElement } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 export default customElements.define(
     "custom-list-vedlegg",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                render: (host, component) => {
+                    const htmlAttributes = new CustomElementHtmlAttributes(component);
+                    host.innerHTML = "";
+                    host.appendChild(createCustomElement(component?.isEmpty ? "custom-field" : "custom-list", htmlAttributes));
                 }
-            } else if (component?.isEmpty) {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-field", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = "";
-                this.appendChild(createCustomElement("custom-list", htmlAttributes));
-                addDevToolsOverlay(this, component, "data");
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-list-vedlegg/index.js
+++ b/src/components/data-components/custom-list-vedlegg/index.js
@@ -21,11 +21,13 @@ export default customElements.define(
                 }
             } else if (component?.isEmpty) {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-field", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-field", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             } else {
                 const htmlAttributes = new CustomElementHtmlAttributes(component);
-                this.innerHTML = createCustomElement("custom-list", htmlAttributes).outerHTML;
+                this.innerHTML = "";
+                this.appendChild(createCustomElement("custom-list", htmlAttributes));
                 addDevToolsOverlay(this, component, "data");
             }
         }

--- a/src/components/data-components/custom-matrix-data/index.js
+++ b/src/components/data-components/custom-matrix-data/index.js
@@ -1,10 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderMatrixElement } from "./renderers.js";
@@ -15,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-matrix-data",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const matrixElement = renderMatrixElement(component);
+                    host.appendChild(matrixElement);
                 }
-            } else {
-                const matrixElement = renderMatrixElement(component);
-                this.appendChild(matrixElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-paragraph-text/index.js
+++ b/src/components/data-components/custom-paragraph-text/index.js
@@ -11,7 +11,8 @@ export default customElements.define(
         connectedCallback() {
             const component = instantiateComponent(this);
             const htmlAttributes = new CustomElementHtmlAttributes(component);
-            this.innerHTML = createCustomElement("custom-paragraph", htmlAttributes).outerHTML;
+            this.innerHTML = "";
+            this.appendChild(createCustomElement("custom-paragraph", htmlAttributes));
             addDevToolsOverlay(this, component, "data");
         }
     }

--- a/src/components/data-components/custom-subheader-text/index.js
+++ b/src/components/data-components/custom-subheader-text/index.js
@@ -14,7 +14,8 @@ export default customElements.define(
         connectedCallback() {
             const component = instantiateComponent(this);
             const htmlAttributes = new CustomElementHtmlAttributes(component);
-            this.innerHTML = createCustomElement("custom-paragraph", htmlAttributes).outerHTML;
+            this.innerHTML = "";
+            this.appendChild(createCustomElement("custom-paragraph", htmlAttributes));
             addDevToolsOverlay(this, component, "data");
         }
     }

--- a/src/components/data-components/custom-summation-arealdisponering/index.js
+++ b/src/components/data-components/custom-summation-arealdisponering/index.js
@@ -1,10 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEmptyFieldText, renderHeaderElement, renderSummationArealdisponering } from "./renderers.js";
@@ -13,31 +8,22 @@ export default customElements.define(
     "custom-summation-arealdisponering",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    if (component?.isEmpty) {
+                        const emptyFieldTextElement = renderEmptyFieldText(component);
+                        host.appendChild(emptyFieldTextElement);
+                    } else {
+                        const summationArealdisponeringElement = renderSummationArealdisponering(component);
+                        if (component?.resourceValues?.title && component?.hideTitle !== true) {
+                            host.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
+                        }
+                        host.appendChild(summationArealdisponeringElement);
+                    }
                 }
-            } else if (component?.isEmpty) {
-                const emptyFieldTextElement = renderEmptyFieldText(component);
-                this.appendChild(emptyFieldTextElement);
-                addDevToolsOverlay(this, component, "data");
-            } else {
-                const summationArealdisponeringElement = renderSummationArealdisponering(component);
-                if (component?.resourceValues?.title && component?.hideTitle !== true) {
-                    this.appendChild(renderHeaderElement(component?.resourceValues?.title, component?.size));
-                }
-                this.appendChild(summationArealdisponeringElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-summation-data/index.js
+++ b/src/components/data-components/custom-summation-data/index.js
@@ -1,10 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderSummationData } from "./renderers.js";
@@ -13,24 +8,14 @@ export default customElements.define(
     "custom-summation-data",
     class extends HTMLElement {
         connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const summationDataElement = renderSummationData(component);
+                    host.appendChild(summationDataElement);
                 }
-            } else {
-                const summationDataElement = renderSummationData(component);
-                this.appendChild(summationDataElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-ansvarsomraade/index.js
+++ b/src/components/data-components/custom-table-ansvarsomraade/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderAnsvarsomraadeTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-ansvarsomraade",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const ansvarsomraadeTableElement = renderAnsvarsomraadeTable(component);
+                    host.appendChild(ansvarsomraadeTableElement);
                 }
-            } else {
-                const ansvarsomraadeTableElement = renderAnsvarsomraadeTable(component);
-                this.appendChild(ansvarsomraadeTableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-ansvarsrett-ansvarsomraade/index.js
+++ b/src/components/data-components/custom-table-ansvarsrett-ansvarsomraade/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderAnsvarsrettAnsvarsomraadeTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-ansvarsrett-ansvarsomraade",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const ansvarsrettAnsvarsomraadeTableElement = renderAnsvarsrettAnsvarsomraadeTable(component);
+                    host.appendChild(ansvarsrettAnsvarsomraadeTableElement);
                 }
-            } else {
-                const ansvarsrettAnsvarsomraadeTableElement = renderAnsvarsrettAnsvarsomraadeTable(component);
-                this.appendChild(ansvarsrettAnsvarsomraadeTableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-arbeidsplasser/index.js
+++ b/src/components/data-components/custom-table-arbeidsplasser/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderArbeidsplasserTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-arbeidsplasser",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const partTable = renderArbeidsplasserTable(component);
+                    host.appendChild(partTable);
                 }
-            } else {
-                const partTable = renderArbeidsplasserTable(component);
-                this.appendChild(partTable);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-data/index.js
+++ b/src/components/data-components/custom-table-data/index.js
@@ -1,10 +1,5 @@
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderTableElement } from "./renderers.js";
@@ -15,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-data",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const tableElement = renderTableElement(component);
+                    host.appendChild(tableElement);
                 }
-            } else {
-                const tableElement = renderTableElement(component);
-                this.appendChild(tableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-eiendom/index.js
+++ b/src/components/data-components/custom-table-eiendom/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEiendomTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-eiendom",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const eiendomTableElement = renderEiendomTable(component);
+                    host.appendChild(eiendomTableElement);
                 }
-            } else {
-                const eiendomTableElement = renderEiendomTable(component);
-                this.appendChild(eiendomTableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-nabo-gjenboer-eiendom/index.js
+++ b/src/components/data-components/custom-table-nabo-gjenboer-eiendom/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderEiendomTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-nabo-gjenboer-eiendom",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const eiendomTableElement = renderEiendomTable(component);
+                    host.appendChild(eiendomTableElement);
                 }
-            } else {
-                const eiendomTableElement = renderEiendomTable(component);
-                this.appendChild(eiendomTableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-omraaderisiko/index.js
+++ b/src/components/data-components/custom-table-omraaderisiko/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderOmraaderisikoTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-omraaderisiko",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const omraaderisikoTableElement = renderOmraaderisikoTable(component);
+                    host.appendChild(omraaderisikoTableElement);
                 }
-            } else {
-                const omraaderisikoTableElement = renderOmraaderisikoTable(component);
-                this.appendChild(omraaderisikoTableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-part-gjennomfoeringsplan/index.js
+++ b/src/components/data-components/custom-table-part-gjennomfoeringsplan/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderPartTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-part-gjennomfoeringsplan",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const partTable = renderPartTable(component);
+                    host.appendChild(partTable);
                 }
-            } else {
-                const partTable = renderPartTable(component);
-                this.appendChild(partTable);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-part/index.js
+++ b/src/components/data-components/custom-table-part/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderPartTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-part",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const partTable = renderPartTable(component);
+                    host.appendChild(partTable);
                 }
-            } else {
-                const partTable = renderPartTable(component);
-                this.appendChild(partTable);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/data-components/custom-table-plan/index.js
+++ b/src/components/data-components/custom-table-plan/index.js
@@ -1,8 +1,5 @@
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 
 // Local functions
 import { renderPlanTable } from "./renderers.js";
@@ -13,25 +10,15 @@ import "./styles.css" with { type: "css" };
 export default customElements.define(
     "custom-table-plan",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-            if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "data");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "data",
+                withFeedback: true,
+                render: (host, component) => {
+                    const planTableElement = renderPlanTable(component);
+                    host.appendChild(planTableElement);
                 }
-            } else {
-                const planTableElement = renderPlanTable(component);
-                this.appendChild(planTableElement);
-                addDevToolsOverlay(this, component, "data");
-            }
-            const feedbackListElement = component?.hasValidationMessages && renderFeedbackListElement(component?.validationMessages);
-            if (feedbackListElement) {
-                this.appendChild(feedbackListElement);
-            }
+            });
         }
     }
 );

--- a/src/components/layout-components/dispensasjon/index.js
+++ b/src/components/layout-components/dispensasjon/index.js
@@ -1,13 +1,10 @@
 // Dependencies
 import { appendChildren } from "@arkitektum/altinn-studio-custom-components-utils";
 
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement, renderLayoutContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderLayoutContainerElement } from "../../../functions/helpers.js";
 
 // Local functions
 import {
@@ -49,126 +46,119 @@ import {
 export default customElements.define(
     "custom-dispensasjon",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "layout",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const layoutContainerElement = renderLayoutContainerElement();
+                    const dispensasjonHeaderElement = renderDispensasjonHeader(component);
+                    const dispensasjonsreferanseElement = renderDispensasjonsreferanse(component);
+                    const metadataFtbIdElement = renderMetadataFtbId(component);
+                    const kommunensSaksnummerElement = renderKommunensSaksnummer(component);
+                    const soeknadGjelderHeaderElement = renderSoeknadGjelderHeader(component);
+                    const eiendomByggestedElement = renderEiendomByggestedElement(component);
+                    const tiltakstyperHeaderElement = renderTiltakstyperHeader(component);
+                    const tiltakstyperKodeElement = renderTiltakstyperKode(component);
+                    const tiltakshaverElement = renderTiltakshaver(component);
+                    const tiltakshaverAdresseElement = renderTiltakshaverAdresse(component);
+                    const tiltakshaverKontaktpersonElement = renderTiltakshaverKontaktperson(component);
+                    const tiltakshaverKontaktpersonAdresseElement = renderTiltakshaverKontaktpersonAdresse(component);
+                    const dispensasjonHeader2Element = renderDispensasjonHeader(component, "h2");
+                    const dispensasjonsbeskrivelseElement = renderDispensasjonsbeskrivelse(component);
+                    const dispensasjonFraHeaderElement = renderDispensasjonFraHeader(component);
+                    const plannavnElement = renderPlannavn(component);
+                    const nasjonalArealplanIdPlanIdentifikasjonElement = renderNasjonalArealplanIdPlanIdentifikasjon(component);
+                    const bestemmelsestypeElement = renderBestemmelsestype(component);
+                    const paragrafnummerElement = renderParagrafnummer(component);
+                    const stedfestingHeaderElement = renderStedfestingHeader(component);
+                    const stedfestingPosisjonKoordinatsystemElement = renderStedfestingPosisjonKoordinatsystem(component);
+                    const stedfestingPosisjonKoordinaterElement = renderStedfestingPosisjonKoordinater(component);
+                    const stedfestingVertikalnivaaElement = renderStedfestingVertikalnivaa(component);
+                    const varighetHeaderElement = renderVarighetHeader(component);
+                    const varighetOenskesVarigDispensasjonElement = renderOensketVarighet(component);
+                    const begrunnelseHeaderElement = renderBegrunnelseHeader(component);
+                    const begrunnelseHensynBakBestemmelsenElement = renderBegrunnelseHensynBakBestemmelsen(component);
+                    const begrunnelseVurderingHensynBakBestemmelsenElement = renderBegrunnelseVurderingHensynBakBestemmelsen(component);
+                    const begrunnelseVurderingHensynOverordnetElement = renderBegrunnelseVurderingHensynOverordnet(component);
+                    const begrunnelseFordelerElement = renderBegrunnelseFordeler(component);
+                    const begrunnelseUlemperElement = renderBegrunnelseUlemper(component);
+                    const begrunnelseSamletBegrunnelseElement = renderBegrunnelseSamletBegrunnelse(component);
+                    const generelleVilkaarNorskSvenskDanskHeaderElement = renderGenerelleVilkaarNorskSvenskDanskHeader(component);
+                    const renderedGenerelleVilkaarNorskSvenskDanskElement = renderGenerelleVilkaarNorskSvenskDansk(component);
 
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "layout");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+                    const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
+
+                    // Intro
+                    appendChildren(layoutContainerElement, [
+                        dispensasjonHeaderElement,
+                        dispensasjonsreferanseElement,
+                        metadataFtbIdElement,
+                        kommunensSaksnummerElement
+                    ]);
+
+                    // Soeknad gjelder
+                    appendChildren(layoutContainerElement, [
+                        soeknadGjelderHeaderElement,
+                        eiendomByggestedElement,
+                        tiltakstyperHeaderElement,
+                        tiltakstyperKodeElement
+                    ]);
+
+                    // Tiltakshaver
+                    appendChildren(layoutContainerElement, [
+                        tiltakshaverElement,
+                        tiltakshaverAdresseElement,
+                        tiltakshaverKontaktpersonElement,
+                        tiltakshaverKontaktpersonAdresseElement
+                    ]);
+
+                    // Dispensasjonsbeskrivelse
+                    appendChildren(layoutContainerElement, [dispensasjonHeader2Element, dispensasjonsbeskrivelseElement]);
+
+                    // Dispensasjon fra
+                    appendChildren(layoutContainerElement, [
+                        dispensasjonFraHeaderElement,
+                        plannavnElement,
+                        nasjonalArealplanIdPlanIdentifikasjonElement,
+                        bestemmelsestypeElement,
+                        paragrafnummerElement
+                    ]);
+
+                    // Stedfesting
+                    appendChildren(layoutContainerElement, [
+                        stedfestingHeaderElement,
+                        stedfestingPosisjonKoordinatsystemElement,
+                        stedfestingPosisjonKoordinaterElement,
+                        stedfestingVertikalnivaaElement
+                    ]);
+
+                    // Varighet
+                    appendChildren(layoutContainerElement, [varighetHeaderElement, varighetOenskesVarigDispensasjonElement]);
+
+                    // Begrunnelse
+                    appendChildren(layoutContainerElement, [
+                        begrunnelseHeaderElement,
+                        begrunnelseHensynBakBestemmelsenElement,
+                        begrunnelseVurderingHensynBakBestemmelsenElement,
+                        begrunnelseVurderingHensynOverordnetElement,
+                        begrunnelseFordelerElement,
+                        begrunnelseUlemperElement,
+                        begrunnelseSamletBegrunnelseElement
+                    ]);
+
+                    // Erklaering
+                    appendChildren(layoutContainerElement, [
+                        generelleVilkaarNorskSvenskDanskHeaderElement,
+                        renderedGenerelleVilkaarNorskSvenskDanskElement
+                    ]);
+
+                    // Append the validation feedback list element if there are validation messages
+                    appendChildren(layoutContainerElement, [validationFeedbackListElement]);
+
+                    host.appendChild(layoutContainerElement);
                 }
-            } else {
-                const layoutContainerElement = renderLayoutContainerElement();
-                const dispensasjonHeaderElement = renderDispensasjonHeader(component);
-                const dispensasjonsreferanseElement = renderDispensasjonsreferanse(component);
-                const metadataFtbIdElement = renderMetadataFtbId(component);
-                const kommunensSaksnummerElement = renderKommunensSaksnummer(component);
-                const soeknadGjelderHeaderElement = renderSoeknadGjelderHeader(component);
-                const eiendomByggestedElement = renderEiendomByggestedElement(component);
-                const tiltakstyperHeaderElement = renderTiltakstyperHeader(component);
-                const tiltakstyperKodeElement = renderTiltakstyperKode(component);
-                const tiltakshaverElement = renderTiltakshaver(component);
-                const tiltakshaverAdresseElement = renderTiltakshaverAdresse(component);
-                const tiltakshaverKontaktpersonElement = renderTiltakshaverKontaktperson(component);
-                const tiltakshaverKontaktpersonAdresseElement = renderTiltakshaverKontaktpersonAdresse(component);
-                const dispensasjonHeader2Element = renderDispensasjonHeader(component, "h2");
-                const dispensasjonsbeskrivelseElement = renderDispensasjonsbeskrivelse(component);
-                const dispensasjonFraHeaderElement = renderDispensasjonFraHeader(component);
-                const plannavnElement = renderPlannavn(component);
-                const nasjonalArealplanIdPlanIdentifikasjonElement = renderNasjonalArealplanIdPlanIdentifikasjon(component);
-                const bestemmelsestypeElement = renderBestemmelsestype(component);
-                const paragrafnummerElement = renderParagrafnummer(component);
-                const stedfestingHeaderElement = renderStedfestingHeader(component);
-                const stedfestingPosisjonKoordinatsystemElement = renderStedfestingPosisjonKoordinatsystem(component);
-                const stedfestingPosisjonKoordinaterElement = renderStedfestingPosisjonKoordinater(component);
-                const stedfestingVertikalnivaaElement = renderStedfestingVertikalnivaa(component);
-                const varighetHeaderElement = renderVarighetHeader(component);
-                const varighetOenskesVarigDispensasjonElement = renderOensketVarighet(component);
-                const begrunnelseHeaderElement = renderBegrunnelseHeader(component);
-                const begrunnelseHensynBakBestemmelsenElement = renderBegrunnelseHensynBakBestemmelsen(component);
-                const begrunnelseVurderingHensynBakBestemmelsenElement = renderBegrunnelseVurderingHensynBakBestemmelsen(component);
-                const begrunnelseVurderingHensynOverordnetElement = renderBegrunnelseVurderingHensynOverordnet(component);
-                const begrunnelseFordelerElement = renderBegrunnelseFordeler(component);
-                const begrunnelseUlemperElement = renderBegrunnelseUlemper(component);
-                const begrunnelseSamletBegrunnelseElement = renderBegrunnelseSamletBegrunnelse(component);
-                const generelleVilkaarNorskSvenskDanskHeaderElement = renderGenerelleVilkaarNorskSvenskDanskHeader(component);
-                const renderedGenerelleVilkaarNorskSvenskDanskElement = renderGenerelleVilkaarNorskSvenskDansk(component);
-
-                const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
-
-                // Intro
-                appendChildren(layoutContainerElement, [
-                    dispensasjonHeaderElement,
-                    dispensasjonsreferanseElement,
-                    metadataFtbIdElement,
-                    kommunensSaksnummerElement
-                ]);
-
-                // Soeknad gjelder
-                appendChildren(layoutContainerElement, [
-                    soeknadGjelderHeaderElement,
-                    eiendomByggestedElement,
-                    tiltakstyperHeaderElement,
-                    tiltakstyperKodeElement
-                ]);
-
-                // Tiltakshaver
-                appendChildren(layoutContainerElement, [
-                    tiltakshaverElement,
-                    tiltakshaverAdresseElement,
-                    tiltakshaverKontaktpersonElement,
-                    tiltakshaverKontaktpersonAdresseElement
-                ]);
-
-                // Dispensasjonsbeskrivelse
-                appendChildren(layoutContainerElement, [dispensasjonHeader2Element, dispensasjonsbeskrivelseElement]);
-
-                // Dispensasjon fra
-                appendChildren(layoutContainerElement, [
-                    dispensasjonFraHeaderElement,
-                    plannavnElement,
-                    nasjonalArealplanIdPlanIdentifikasjonElement,
-                    bestemmelsestypeElement,
-                    paragrafnummerElement
-                ]);
-
-                // Stedfesting
-                appendChildren(layoutContainerElement, [
-                    stedfestingHeaderElement,
-                    stedfestingPosisjonKoordinatsystemElement,
-                    stedfestingPosisjonKoordinaterElement,
-                    stedfestingVertikalnivaaElement
-                ]);
-
-                // Varighet
-                appendChildren(layoutContainerElement, [varighetHeaderElement, varighetOenskesVarigDispensasjonElement]);
-
-                // Begrunnelse
-                appendChildren(layoutContainerElement, [
-                    begrunnelseHeaderElement,
-                    begrunnelseHensynBakBestemmelsenElement,
-                    begrunnelseVurderingHensynBakBestemmelsenElement,
-                    begrunnelseVurderingHensynOverordnetElement,
-                    begrunnelseFordelerElement,
-                    begrunnelseUlemperElement,
-                    begrunnelseSamletBegrunnelseElement
-                ]);
-
-                // Erklaering
-                appendChildren(layoutContainerElement, [
-                    generelleVilkaarNorskSvenskDanskHeaderElement,
-                    renderedGenerelleVilkaarNorskSvenskDanskElement
-                ]);
-
-                // Append the validation feedback list element if there are validation messages
-                appendChildren(layoutContainerElement, [validationFeedbackListElement]);
-
-                this.appendChild(layoutContainerElement);
-                addDevToolsOverlay(this, component, "layout");
-            }
+            });
         }
     }
 );

--- a/src/components/layout-components/dispensasjonsvarsel/index.js
+++ b/src/components/layout-components/dispensasjonsvarsel/index.js
@@ -1,13 +1,10 @@
 // Dependencies
 import { appendChildren } from "@arkitektum/altinn-studio-custom-components-utils";
 
-// Classes
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
-
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement, renderLayoutContainerElement } from "../../../functions/helpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderLayoutContainerElement } from "../../../functions/helpers.js";
 
 // Local functions
 import {
@@ -24,49 +21,42 @@ import {
 export default customElements.define(
     "custom-dispensasjonsvarsel",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "layout",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const layoutContainerElement = renderLayoutContainerElement();
+                    const dispensasjonsvarselHeaderElement = renderDispensasjonsvarselHeader(component);
+                    const emneElement = renderEmne(component);
+                    const bestemmelseHeaderElement = renderBestemmelseHeader(component);
+                    const plannavnParagrafnummerElement = renderPlannavnParagrafnummer(component);
+                    const bestemmelsestekstElement = renderBestemmelsestekst(component);
+                    const dispVarselBeskrivelseHeaderElement = renderDispVarselBeskrivelseHeader(component);
+                    const dispVarselBeskrivelseElement = renderDispVarselBeskrivelse(component);
+                    const spoersmaalOmDispensasjonssoeknadenElement = renderSpoersmaalOmDispensasjonssoeknaden(component);
 
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "layout");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+                    const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
+
+                    // Intro
+                    appendChildren(layoutContainerElement, [dispensasjonsvarselHeaderElement, emneElement]);
+
+                    // Bestemmelse
+                    appendChildren(layoutContainerElement, [bestemmelseHeaderElement, plannavnParagrafnummerElement, bestemmelsestekstElement]);
+
+                    // Dispensasjonsvarsel beskrivelse
+                    appendChildren(layoutContainerElement, [
+                        dispVarselBeskrivelseHeaderElement,
+                        dispVarselBeskrivelseElement,
+                        spoersmaalOmDispensasjonssoeknadenElement
+                    ]);
+
+                    // Append the validation feedback list element if there are validation messages
+                    appendChildren(layoutContainerElement, [validationFeedbackListElement]);
+
+                    host.appendChild(layoutContainerElement);
                 }
-            } else {
-                const layoutContainerElement = renderLayoutContainerElement();
-                const dispensasjonsvarselHeaderElement = renderDispensasjonsvarselHeader(component);
-                const emneElement = renderEmne(component);
-                const bestemmelseHeaderElement = renderBestemmelseHeader(component);
-                const plannavnParagrafnummerElement = renderPlannavnParagrafnummer(component);
-                const bestemmelsestekstElement = renderBestemmelsestekst(component);
-                const dispVarselBeskrivelseHeaderElement = renderDispVarselBeskrivelseHeader(component);
-                const dispVarselBeskrivelseElement = renderDispVarselBeskrivelse(component);
-                const spoersmaalOmDispensasjonssoeknadenElement = renderSpoersmaalOmDispensasjonssoeknaden(component);
-
-                const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
-
-                // Intro
-                appendChildren(layoutContainerElement, [dispensasjonsvarselHeaderElement, emneElement]);
-
-                // Bestemmelse
-                appendChildren(layoutContainerElement, [bestemmelseHeaderElement, plannavnParagrafnummerElement, bestemmelsestekstElement]);
-
-                // Dispensasjonsvarsel beskrivelse
-                appendChildren(layoutContainerElement, [
-                    dispVarselBeskrivelseHeaderElement,
-                    dispVarselBeskrivelseElement,
-                    spoersmaalOmDispensasjonssoeknadenElement
-                ]);
-
-                // Append the validation feedback list element if there are validation messages
-                appendChildren(layoutContainerElement, [validationFeedbackListElement]);
-
-                this.appendChild(layoutContainerElement);
-                addDevToolsOverlay(this, component, "layout");
-            }
+            });
         }
     }
 );

--- a/src/components/layout-components/gjennomfoeringsplan/index.js
+++ b/src/components/layout-components/gjennomfoeringsplan/index.js
@@ -2,10 +2,9 @@
 import { appendChildren } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement, renderLayoutContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderLayoutContainerElement } from "../../../functions/helpers.js";
 import { setPageOrientation } from "../../../functions/printHelpers.js";
 
 // Local functions
@@ -25,62 +24,55 @@ import {
 export default customElements.define(
     "custom-gjennomfoeringsplan",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
-
+        connectedCallback() {
+            // Runs unconditionally (on both the hidden and rendered paths), so it stays outside the helper.
             setPageOrientation("landscape");
+            renderCustomComponent(this, {
+                type: "layout",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const layoutContainerElement = renderLayoutContainerElement();
 
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "layout");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+                    const headerElement = renderGjennomfoeringsplanHeader(component, "h1");
+                    const subHeaderElement = renderGjennomfoeringsplanSubHeader(component);
+
+                    const versjonElement = renderVersjon(component);
+                    const kommunensSaksnummerElement = renderKommunensSaksnummer(component);
+                    const metadataProsjektnavnElement = renderMetadataProsjektnavn(component);
+                    const metadataFtbIdElement = renderMetadataFtbId(component);
+
+                    const planenGjelderHeaderElement = renderPlanenGjelderHeader(component);
+                    const eiendomByggestedElement = renderEiendomByggested(component);
+                    const ansvarligSoekerElement = renderAnsvarligSoeker(component);
+                    const ansvarsomraadeElement = renderAnsvarsomraade(component);
+
+                    const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
+
+                    // Header and subheader
+                    appendChildren(layoutContainerElement, [headerElement, subHeaderElement]);
+
+                    // Intro
+                    appendChildren(layoutContainerElement, [
+                        versjonElement,
+                        kommunensSaksnummerElement,
+                        metadataProsjektnavnElement,
+                        metadataFtbIdElement
+                    ]);
+
+                    // Planen gjelder
+                    appendChildren(layoutContainerElement, [
+                        planenGjelderHeaderElement,
+                        eiendomByggestedElement,
+                        ansvarligSoekerElement,
+                        ansvarsomraadeElement
+                    ]);
+
+                    // Append the validation feedback list element if there are validation messages
+                    appendChildren(layoutContainerElement, [validationFeedbackListElement]);
+
+                    host.appendChild(layoutContainerElement);
                 }
-            } else {
-                const layoutContainerElement = renderLayoutContainerElement();
-
-                const headerElement = renderGjennomfoeringsplanHeader(component, "h1");
-                const subHeaderElement = renderGjennomfoeringsplanSubHeader(component);
-
-                const versjonElement = renderVersjon(component);
-                const kommunensSaksnummerElement = renderKommunensSaksnummer(component);
-                const metadataProsjektnavnElement = renderMetadataProsjektnavn(component);
-                const metadataFtbIdElement = renderMetadataFtbId(component);
-
-                const planenGjelderHeaderElement = renderPlanenGjelderHeader(component);
-                const eiendomByggestedElement = renderEiendomByggested(component);
-                const ansvarligSoekerElement = renderAnsvarligSoeker(component);
-                const ansvarsomraadeElement = renderAnsvarsomraade(component);
-
-                const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
-
-                // Header and subheader
-                appendChildren(layoutContainerElement, [headerElement, subHeaderElement]);
-
-                // Intro
-                appendChildren(layoutContainerElement, [
-                    versjonElement,
-                    kommunensSaksnummerElement,
-                    metadataProsjektnavnElement,
-                    metadataFtbIdElement
-                ]);
-
-                // Planen gjelder
-                appendChildren(layoutContainerElement, [
-                    planenGjelderHeaderElement,
-                    eiendomByggestedElement,
-                    ansvarligSoekerElement,
-                    ansvarsomraadeElement
-                ]);
-
-                // Append the validation feedback list element if there are validation messages
-                appendChildren(layoutContainerElement, [validationFeedbackListElement]);
-
-                this.appendChild(layoutContainerElement);
-                addDevToolsOverlay(this, component, "layout");
-            }
+            });
         }
     }
 );

--- a/src/components/layout-components/gjenpart-nabovarsel/index.js
+++ b/src/components/layout-components/gjenpart-nabovarsel/index.js
@@ -2,10 +2,9 @@
 import { appendChildren } from "@arkitektum/altinn-studio-custom-components-utils";
 
 // Global functions
-import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "../../../functions/devToolsHelpers.js";
-import { getComponentContainerElement, renderLayoutContainerElement } from "../../../functions/helpers.js";
-import { instantiateComponent } from "../../../functions/componentHelpers.js";
+import { renderCustomComponent } from "../../../functions/componentRenderHelpers.js";
 import { renderFeedbackListElement } from "../../../functions/feedbackHelpers.js";
+import { renderLayoutContainerElement } from "../../../functions/helpers.js";
 
 // Local functions
 import {
@@ -29,84 +28,77 @@ import {
 export default customElements.define(
     "custom-gjenpart-nabovarsel",
     class extends HTMLElement {
-        async connectedCallback() {
-            const component = instantiateComponent(this);
-            const componentContainerElement = getComponentContainerElement(this);
+        connectedCallback() {
+            renderCustomComponent(this, {
+                type: "layout",
+                alwaysHideWhenEmpty: true,
+                render: (host, component) => {
+                    const layoutContainerElement = renderLayoutContainerElement();
 
-            if (component.isEmpty && !!componentContainerElement) {
-                if (isDevMode()) {
-                    const hiddenEl = renderHiddenDevToolsElement(this, component, "layout");
-                    if (hiddenEl) this.appendChild(hiddenEl);
-                } else {
-                    componentContainerElement.style.display = "none";
+                    const headerElement = renderGjenpartNabovarselHeader(component, "h1");
+                    const subHeaderElement = renderGjenpartNabovarselSubHeader(component);
+
+                    const metadataProsjektnavnElement = renderMetadataProsjektnavn(component);
+                    const soekerElement = renderSoekerElement(component);
+
+                    const eiendomByggestedElement = renderEiendomByggestedElement(component);
+
+                    const detErVarsletOmHeaderElement = renderDetErVarsletOmHeader(component);
+                    const soeknadGjelderTypeElement = renderSoeknadGjelderTypeElement(component);
+                    const soeknadGjelderBrukTiltaksformaalElement = renderSoeknadGjelderBrukTiltaksformaalElement(component);
+                    const soeknadGjelderBrukBeskrivPlanlagtFormaalElement = renderSoeknadGjelderBrukBeskrivPlanlagtFormaalElement(component);
+
+                    const planerGjeldendePlanHeaderElement = renderPlanerGjeldendePlanHeaderElement(component);
+                    const planerGjeldendePlanNavnElement = renderPlanGjeldendePlanNavnElement(component);
+                    const planerGjeldendePlanPlantypeElement = renderPlanerGjeldendePlanPlantypeElement(component);
+
+                    const dispensasjonOversiktElement = renderDispensasjonOversiktElement(component);
+
+                    const kontaktpersonForNabovarseletElement = renderKontaktpersonForNabovarseletElement(component);
+
+                    const naboGjenboerEiendomElement = renderNaboGjenboerEiendom(component);
+
+                    const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
+
+                    // Header and subheader
+                    appendChildren(layoutContainerElement, [headerElement, subHeaderElement]);
+
+                    // Metadata
+                    appendChildren(layoutContainerElement, [metadataProsjektnavnElement, soekerElement]);
+
+                    // Eiendom og byggested
+                    appendChildren(layoutContainerElement, [eiendomByggestedElement]);
+
+                    // Det er varslet om
+                    appendChildren(layoutContainerElement, [
+                        detErVarsletOmHeaderElement,
+                        soeknadGjelderTypeElement,
+                        soeknadGjelderBrukTiltaksformaalElement,
+                        soeknadGjelderBrukBeskrivPlanlagtFormaalElement
+                    ]);
+
+                    // Gjeldende plan
+                    appendChildren(layoutContainerElement, [
+                        planerGjeldendePlanHeaderElement,
+                        planerGjeldendePlanNavnElement,
+                        planerGjeldendePlanPlantypeElement
+                    ]);
+
+                    // Dispensasjonsoversikt
+                    appendChildren(layoutContainerElement, [dispensasjonOversiktElement]);
+
+                    // Kontaktperson for nabovarselet
+                    appendChildren(layoutContainerElement, [kontaktpersonForNabovarseletElement]);
+
+                    // Nabovarsel med vedlegg er sendt til følgende naboer
+                    appendChildren(layoutContainerElement, [naboGjenboerEiendomElement]);
+
+                    // Append the validation feedback list element if there are validation messages
+                    appendChildren(layoutContainerElement, [validationFeedbackListElement]);
+
+                    host.appendChild(layoutContainerElement);
                 }
-            } else {
-                const layoutContainerElement = renderLayoutContainerElement();
-
-                const headerElement = renderGjenpartNabovarselHeader(component, "h1");
-                const subHeaderElement = renderGjenpartNabovarselSubHeader(component);
-
-                const metadataProsjektnavnElement = renderMetadataProsjektnavn(component);
-                const soekerElement = renderSoekerElement(component);
-
-                const eiendomByggestedElement = renderEiendomByggestedElement(component);
-
-                const detErVarsletOmHeaderElement = renderDetErVarsletOmHeader(component);
-                const soeknadGjelderTypeElement = renderSoeknadGjelderTypeElement(component);
-                const soeknadGjelderBrukTiltaksformaalElement = renderSoeknadGjelderBrukTiltaksformaalElement(component);
-                const soeknadGjelderBrukBeskrivPlanlagtFormaalElement = renderSoeknadGjelderBrukBeskrivPlanlagtFormaalElement(component);
-
-                const planerGjeldendePlanHeaderElement = renderPlanerGjeldendePlanHeaderElement(component);
-                const planerGjeldendePlanNavnElement = renderPlanGjeldendePlanNavnElement(component);
-                const planerGjeldendePlanPlantypeElement = renderPlanerGjeldendePlanPlantypeElement(component);
-
-                const dispensasjonOversiktElement = renderDispensasjonOversiktElement(component);
-
-                const kontaktpersonForNabovarseletElement = renderKontaktpersonForNabovarseletElement(component);
-
-                const naboGjenboerEiendomElement = renderNaboGjenboerEiendom(component);
-
-                const validationFeedbackListElement = renderFeedbackListElement(component?.validationMessages);
-
-                // Header and subheader
-                appendChildren(layoutContainerElement, [headerElement, subHeaderElement]);
-
-                // Metadata
-                appendChildren(layoutContainerElement, [metadataProsjektnavnElement, soekerElement]);
-
-                // Eiendom og byggested
-                appendChildren(layoutContainerElement, [eiendomByggestedElement]);
-
-                // Det er varslet om
-                appendChildren(layoutContainerElement, [
-                    detErVarsletOmHeaderElement,
-                    soeknadGjelderTypeElement,
-                    soeknadGjelderBrukTiltaksformaalElement,
-                    soeknadGjelderBrukBeskrivPlanlagtFormaalElement
-                ]);
-
-                // Gjeldende plan
-                appendChildren(layoutContainerElement, [
-                    planerGjeldendePlanHeaderElement,
-                    planerGjeldendePlanNavnElement,
-                    planerGjeldendePlanPlantypeElement
-                ]);
-
-                // Dispensasjonsoversikt
-                appendChildren(layoutContainerElement, [dispensasjonOversiktElement]);
-
-                // Kontaktperson for nabovarselet
-                appendChildren(layoutContainerElement, [kontaktpersonForNabovarseletElement]);
-
-                // Nabovarsel med vedlegg er sendt til følgende naboer
-                appendChildren(layoutContainerElement, [naboGjenboerEiendomElement]);
-
-                // Append the validation feedback list element if there are validation messages
-                appendChildren(layoutContainerElement, [validationFeedbackListElement]);
-
-                this.appendChild(layoutContainerElement);
-                addDevToolsOverlay(this, component, "layout");
-            }
+            });
         }
     }
 );

--- a/src/functions/componentRenderHelpers.js
+++ b/src/functions/componentRenderHelpers.js
@@ -8,8 +8,9 @@ import { renderFeedbackListElement } from "./feedbackHelpers.js";
  * Runs the shared render lifecycle used by (almost) every custom element's `connectedCallback`:
  *
  * 1. Instantiate the component class from the element's attributes.
- * 2. If the component is configured with `hideIfEmpty` and resolves to empty, hide its container
- *    (or, in DevTools mode, render a hidden-element placeholder badge).
+ * 2. If the component resolves to empty and should be hidden, hide its container (or, in DevTools mode, render a
+ *    hidden-element placeholder badge). By default this is gated on the component's `hideIfEmpty` flag; pass
+ *    `alwaysHideWhenEmpty` to hide whenever the component is empty regardless of the flag.
  * 3. Otherwise invoke the component-specific `render` callback and attach the DevTools overlay.
  * 4. Optionally append a validation feedback list when `withFeedback` is set and the component has messages.
  *
@@ -21,12 +22,17 @@ import { renderFeedbackListElement } from "./feedbackHelpers.js";
  * @param {string} options.type - DevTools category: "base", "data", or "layout".
  * @param {(host: HTMLElement, component: Object) => void} options.render - Renders the component's content into `host`.
  * @param {boolean} [options.withFeedback=false] - When true, append a feedback list if the component has validation messages.
+ * @param {boolean} [options.alwaysHideWhenEmpty=false] - When true, hide an empty component regardless of its `hideIfEmpty` flag.
  * @returns {Object} The instantiated component.
  */
-export function renderCustomComponent(host, { type, render, withFeedback = false }) {
+export function renderCustomComponent(host, { type, render, withFeedback = false, alwaysHideWhenEmpty = false }) {
     const component = instantiateComponent(host);
     const componentContainerElement = getComponentContainerElement(host);
-    if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
+    const shouldHideWhenEmpty = alwaysHideWhenEmpty || component?.hideIfEmpty;
+    if (component?.tagName == "custom-grouplist-sjekklistekrav") {
+        console.log({ component, alwaysHideWhenEmpty, shouldHideWhenEmpty, componentContainerElement });
+    }
+    if (shouldHideWhenEmpty && component?.isEmpty && !!componentContainerElement) {
         if (isDevMode()) {
             const hiddenEl = renderHiddenDevToolsElement(host, component, type);
             if (hiddenEl) host.appendChild(hiddenEl);

--- a/src/functions/componentRenderHelpers.js
+++ b/src/functions/componentRenderHelpers.js
@@ -29,9 +29,6 @@ export function renderCustomComponent(host, { type, render, withFeedback = false
     const component = instantiateComponent(host);
     const componentContainerElement = getComponentContainerElement(host);
     const shouldHideWhenEmpty = alwaysHideWhenEmpty || component?.hideIfEmpty;
-    if (component?.tagName == "custom-grouplist-sjekklistekrav") {
-        console.log({ component, alwaysHideWhenEmpty, shouldHideWhenEmpty, componentContainerElement });
-    }
     if (shouldHideWhenEmpty && component?.isEmpty && !!componentContainerElement) {
         if (isDevMode()) {
             const hiddenEl = renderHiddenDevToolsElement(host, component, type);

--- a/src/functions/componentRenderHelpers.js
+++ b/src/functions/componentRenderHelpers.js
@@ -1,0 +1,47 @@
+// Global functions
+import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "./devToolsHelpers.js";
+import { getComponentContainerElement } from "./helpers.js";
+import { instantiateComponent } from "./componentHelpers.js";
+import { renderFeedbackListElement } from "./feedbackHelpers.js";
+
+/**
+ * Runs the shared render lifecycle used by (almost) every custom element's `connectedCallback`:
+ *
+ * 1. Instantiate the component class from the element's attributes.
+ * 2. If the component is configured with `hideIfEmpty` and resolves to empty, hide its container
+ *    (or, in DevTools mode, render a hidden-element placeholder badge).
+ * 3. Otherwise invoke the component-specific `render` callback and attach the DevTools overlay.
+ * 4. Optionally append a validation feedback list when `withFeedback` is set and the component has messages.
+ *
+ * Component-specific markup lives entirely in the `render` callback, so callers keep full control over how
+ * (and whether) they clear/append content.
+ *
+ * @param {HTMLElement} host - The custom element instance (`this` inside `connectedCallback`).
+ * @param {Object} options - Lifecycle options.
+ * @param {string} options.type - DevTools category: "base", "data", or "layout".
+ * @param {(host: HTMLElement, component: Object) => void} options.render - Renders the component's content into `host`.
+ * @param {boolean} [options.withFeedback=false] - When true, append a feedback list if the component has validation messages.
+ * @returns {Object} The instantiated component.
+ */
+export function renderCustomComponent(host, { type, render, withFeedback = false }) {
+    const component = instantiateComponent(host);
+    const componentContainerElement = getComponentContainerElement(host);
+    if (component?.hideIfEmpty && component.isEmpty && !!componentContainerElement) {
+        if (isDevMode()) {
+            const hiddenEl = renderHiddenDevToolsElement(host, component, type);
+            if (hiddenEl) host.appendChild(hiddenEl);
+        } else {
+            componentContainerElement.style.display = "none";
+        }
+    } else {
+        render(host, component);
+        addDevToolsOverlay(host, component, type);
+    }
+    if (withFeedback && component?.hasValidationMessages) {
+        const feedbackListElement = renderFeedbackListElement(component?.validationMessages);
+        if (feedbackListElement) {
+            host.appendChild(feedbackListElement);
+        }
+    }
+    return component;
+}

--- a/src/functions/componentRenderHelpers.test.js
+++ b/src/functions/componentRenderHelpers.test.js
@@ -1,0 +1,85 @@
+import { addDevToolsOverlay, isDevMode, renderHiddenDevToolsElement } from "./devToolsHelpers.js";
+import { getComponentContainerElement } from "./helpers.js";
+import { instantiateComponent } from "./componentHelpers.js";
+import { renderCustomComponent } from "./componentRenderHelpers";
+import { renderFeedbackListElement } from "./feedbackHelpers.js";
+
+jest.mock("./componentHelpers.js", () => ({ instantiateComponent: jest.fn() }));
+jest.mock("./devToolsHelpers.js", () => ({
+    addDevToolsOverlay: jest.fn(),
+    isDevMode: jest.fn(),
+    renderHiddenDevToolsElement: jest.fn()
+}));
+jest.mock("./helpers.js", () => ({ getComponentContainerElement: jest.fn() }));
+jest.mock("./feedbackHelpers.js", () => ({ renderFeedbackListElement: jest.fn() }));
+
+describe("renderCustomComponent", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("hides the container and skips render when hideIfEmpty and empty (not dev mode)", () => {
+        const host = document.createElement("div");
+        const container = document.createElement("div");
+        instantiateComponent.mockReturnValue({ hideIfEmpty: true, isEmpty: true });
+        getComponentContainerElement.mockReturnValue(container);
+        isDevMode.mockReturnValue(false);
+        const render = jest.fn();
+
+        renderCustomComponent(host, { type: "data", render });
+
+        expect(container.style.display).toBe("none");
+        expect(render).not.toHaveBeenCalled();
+        expect(addDevToolsOverlay).not.toHaveBeenCalled();
+    });
+
+    it("renders a DevTools placeholder when hidden in dev mode", () => {
+        const host = document.createElement("div");
+        const hidden = document.createElement("span");
+        instantiateComponent.mockReturnValue({ hideIfEmpty: true, isEmpty: true });
+        getComponentContainerElement.mockReturnValue(document.createElement("div"));
+        isDevMode.mockReturnValue(true);
+        renderHiddenDevToolsElement.mockReturnValue(hidden);
+        const render = jest.fn();
+
+        renderCustomComponent(host, { type: "data", render });
+
+        expect(host.contains(hidden)).toBe(true);
+        expect(render).not.toHaveBeenCalled();
+    });
+
+    it("invokes render and attaches the DevTools overlay when not hidden", () => {
+        const host = document.createElement("div");
+        instantiateComponent.mockReturnValue({ isEmpty: false });
+        getComponentContainerElement.mockReturnValue(document.createElement("div"));
+        const render = jest.fn((h) => h.appendChild(document.createElement("p")));
+
+        renderCustomComponent(host, { type: "base", render });
+
+        expect(render).toHaveBeenCalledWith(host, expect.any(Object));
+        expect(addDevToolsOverlay).toHaveBeenCalledWith(host, expect.any(Object), "base");
+        expect(host.querySelector("p")).not.toBeNull();
+    });
+
+    it("appends a feedback list when withFeedback and there are validation messages", () => {
+        const host = document.createElement("div");
+        const feedback = document.createElement("ul");
+        instantiateComponent.mockReturnValue({ isEmpty: false, hasValidationMessages: true, validationMessages: {} });
+        getComponentContainerElement.mockReturnValue(null);
+        renderFeedbackListElement.mockReturnValue(feedback);
+
+        renderCustomComponent(host, { type: "data", render: jest.fn(), withFeedback: true });
+
+        expect(host.contains(feedback)).toBe(true);
+    });
+
+    it("does not append feedback when withFeedback is false", () => {
+        const host = document.createElement("div");
+        instantiateComponent.mockReturnValue({ isEmpty: false, hasValidationMessages: true, validationMessages: {} });
+        getComponentContainerElement.mockReturnValue(null);
+
+        renderCustomComponent(host, { type: "data", render: jest.fn() });
+
+        expect(renderFeedbackListElement).not.toHaveBeenCalled();
+    });
+});

--- a/src/functions/componentRenderHelpers.test.js
+++ b/src/functions/componentRenderHelpers.test.js
@@ -48,6 +48,34 @@ describe("renderCustomComponent", () => {
         expect(render).not.toHaveBeenCalled();
     });
 
+    it("does not hide an empty component without hideIfEmpty by default (renders instead)", () => {
+        const host = document.createElement("div");
+        const container = document.createElement("div");
+        instantiateComponent.mockReturnValue({ isEmpty: true });
+        getComponentContainerElement.mockReturnValue(container);
+        isDevMode.mockReturnValue(false);
+        const render = jest.fn();
+
+        renderCustomComponent(host, { type: "data", render });
+
+        expect(container.style.display).not.toBe("none");
+        expect(render).toHaveBeenCalled();
+    });
+
+    it("hides an empty component when alwaysHideWhenEmpty is set, even without hideIfEmpty", () => {
+        const host = document.createElement("div");
+        const container = document.createElement("div");
+        instantiateComponent.mockReturnValue({ isEmpty: true });
+        getComponentContainerElement.mockReturnValue(container);
+        isDevMode.mockReturnValue(false);
+        const render = jest.fn();
+
+        renderCustomComponent(host, { type: "data", render, alwaysHideWhenEmpty: true });
+
+        expect(container.style.display).toBe("none");
+        expect(render).not.toHaveBeenCalled();
+    });
+
     it("invokes render and attaches the DevTools overlay when not hidden", () => {
         const host = document.createElement("div");
         instantiateComponent.mockReturnValue({ isEmpty: false });

--- a/src/functions/dataFormatHelpers.js
+++ b/src/functions/dataFormatHelpers.js
@@ -77,6 +77,9 @@ export function isValidDateString(dateString) {
  * @returns {string} - The formatted date-time string or an error message if the input is invalid.
  */
 export function formatDateTime(dateTime, language = "default") {
+    if (!dateTime) {
+        return "";
+    }
     if (!isValidDateString(dateTime)) {
         return "Ugyldig datoformat"; // Return an error message for invalid date format
     }
@@ -125,6 +128,9 @@ export function formatDate(date, language = "default") {
  * @returns {string} The formatted time string.
  */
 export function formatTime(time, language = "default") {
+    if (!time) {
+        return "";
+    }
     const timeHasDate = time.includes("T");
     if (!timeHasDate) {
         time = "1970-01-01T" + time; // Append date if not present
@@ -158,6 +164,9 @@ export function formatAR(data) {
  * @returns {string} The formatted string with square meters unit.
  */
 export function formatMeterSquared(value) {
+    if (value === null || value === undefined || value === "") {
+        return "";
+    }
     return `${value} m²`;
 }
 

--- a/src/functions/dataFormatHelpers.js
+++ b/src/functions/dataFormatHelpers.js
@@ -1,6 +1,9 @@
 // Constants
 import { availableDateTimeLanguages, dateTimeFormat, dateTimeLocale } from "../constants/dateTimeFormats.js";
 
+// Global functions
+import { escapeHtml, escapeHtmlAttribute } from "./stringHelpers.js";
+
 /**
  * Returns the provided language if it is included in the list of available date-time languages.
  * Otherwise, returns the default language.
@@ -217,11 +220,6 @@ export function injectAnchorElements(text) {
     // 2) Non-global tester to avoid lastIndex issues
     const isUrl = new RegExp(`^${urlPattern}$`);
 
-    // Basic HTML escape for non-link parts
-    const escapeHtml = (s) => String(s).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
-    // Attribute escape additionally neutralizes the quote that would otherwise break out of the href="" attribute.
-    const escapeAttr = (s) => escapeHtml(s).replaceAll('"', "&quot;");
-
     return text
         .toString()
         .split(splitRegex)
@@ -236,7 +234,7 @@ export function injectAnchorElements(text) {
                 const href = raw.startsWith("http") ? raw : `https://${raw}`;
                 // The URL token can contain quotes/angle brackets (the pattern allows any non-whitespace),
                 // so escape it before interpolating into the attribute and the link text to prevent HTML injection.
-                return `<a href="${escapeAttr(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(raw)}</a>${escapeHtml(trail)}`;
+                return `<a href="${escapeHtmlAttribute(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(raw)}</a>${escapeHtml(trail)}`;
             }
             return escapeHtml(part);
         })

--- a/src/functions/dataFormatHelpers.js
+++ b/src/functions/dataFormatHelpers.js
@@ -217,8 +217,10 @@ export function injectAnchorElements(text) {
     // 2) Non-global tester to avoid lastIndex issues
     const isUrl = new RegExp(`^${urlPattern}$`);
 
-    // Optional: basic HTML escape for non-link parts
+    // Basic HTML escape for non-link parts
     const escapeHtml = (s) => String(s).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+    // Attribute escape additionally neutralizes the quote that would otherwise break out of the href="" attribute.
+    const escapeAttr = (s) => escapeHtml(s).replaceAll('"', "&quot;");
 
     return text
         .toString()
@@ -232,7 +234,9 @@ export function injectAnchorElements(text) {
                 const raw = m[1];
                 const trail = m[2] ?? "";
                 const href = raw.startsWith("http") ? raw : `https://${raw}`;
-                return `<a href="${href}" target="_blank" rel="noopener noreferrer">${raw}</a>${escapeHtml(trail)}`;
+                // The URL token can contain quotes/angle brackets (the pattern allows any non-whitespace),
+                // so escape it before interpolating into the attribute and the link text to prevent HTML injection.
+                return `<a href="${escapeAttr(href)}" target="_blank" rel="noopener noreferrer">${escapeHtml(raw)}</a>${escapeHtml(trail)}`;
             }
             return escapeHtml(part);
         })

--- a/src/functions/dataFormatHelpers.test.js
+++ b/src/functions/dataFormatHelpers.test.js
@@ -105,6 +105,10 @@ describe("formatDateTime", () => {
     it("returns error message for invalid date", () => {
         expect(formatDateTime("not-a-date")).toBe("Ugyldig datoformat");
     });
+    it("returns empty string for empty/undefined input", () => {
+        expect(formatDateTime("")).toBe("");
+        expect(formatDateTime(undefined)).toBe("");
+    });
 });
 
 describe("formatDate", () => {
@@ -134,6 +138,11 @@ describe("formatTime", () => {
     it("parses and formats invalid time string", () => {
         const result = formatTime("13:45", "en");
         expect(typeof result).toBe("string");
+    });
+    it("returns empty string for empty/undefined input without throwing", () => {
+        expect(formatTime("")).toBe("");
+        expect(() => formatTime(undefined)).not.toThrow();
+        expect(formatTime(undefined)).toBe("");
     });
 });
 
@@ -169,6 +178,11 @@ describe("formatString", () => {
         expect(formatString(123, "meterSquared")).toBe("123 m²");
         expect(formatString("456", "meterSquared")).toBe("456 m²");
     });
+    it("formats meterSquared for zero but returns empty for a missing value", () => {
+        expect(formatString(0, "meterSquared")).toBe("0 m²");
+        expect(formatString("", "meterSquared")).toBe("");
+        expect(formatString(undefined, "meterSquared")).toBe("");
+    });
     it("returns input for unknown format", () => {
         expect(formatString("abc", "unknown")).toBe("abc");
     });
@@ -198,5 +212,11 @@ describe("injectAnchorElements", () => {
     });
     it("returns empty string for empty input", () => {
         expect(injectAnchorElements("")).toBe("");
+    });
+    it("escapes an angle-bracket/quote payload in the URL token so it cannot break out of the anchor", () => {
+        const output = injectAnchorElements('http://a.co/"><img src=x onerror=alert(1)>');
+        expect(output).not.toContain("<img");
+        expect(output).toContain("&lt;img");
+        expect(output).toContain("&quot;");
     });
 });

--- a/src/functions/devToolsHelpers.js
+++ b/src/functions/devToolsHelpers.js
@@ -1,3 +1,6 @@
+// Global functions
+import { escapeHtml } from "./stringHelpers.js";
+
 const TYPE_CONFIG = {
     base: { label: "B", color: "#89b4fa", bgColor: "#1a1a35", bgColorHidden: "#1a1a35cc", borderColor: "#3d3d7a", rightPx: 2, typeName: "Base" },
     data: { label: "D", color: "#a6e3a1", bgColor: "#0d2518", bgColorHidden: "#0d2518cc", borderColor: "#2a5e3a", rightPx: 26, typeName: "Data" },
@@ -49,15 +52,6 @@ export function isDevMode() {
  */
 function truncate(str, maxLen = 300) {
     return str.length > maxLen ? str.slice(0, maxLen) + "\u2026" : str;
-}
-
-/**
- * Escapes HTML-special characters so component/prop values can be safely interpolated into the panel's innerHTML.
- * @param {*} str - The value to escape.
- * @returns {string} The escaped string.
- */
-function escapeHtml(str) {
-    return String(str).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }
 
 /**

--- a/src/functions/devToolsHelpers.js
+++ b/src/functions/devToolsHelpers.js
@@ -52,6 +52,15 @@ function truncate(str, maxLen = 300) {
 }
 
 /**
+ * Escapes HTML-special characters so component/prop values can be safely interpolated into the panel's innerHTML.
+ * @param {*} str - The value to escape.
+ * @returns {string} The escaped string.
+ */
+function escapeHtml(str) {
+    return String(str).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+/**
  * Extracts and formats the properties of a component for display in the DevTools panel, filtering out undefined, null, false, and empty string values.
  * @param {*} component - The component object to extract properties from.
  * @returns {Array} An array of key-value pairs representing the component's properties.
@@ -104,14 +113,14 @@ function buildPanel(tagName, elementId, props, hidden, type) {
         ? `<span style="background:#45475a;color:#f38ba8;padding:1px 5px;border-radius:3px;font-size:9px;margin-left:4px;vertical-align:middle;">hidden</span>`
         : "";
 
-    let html = `<div style="font-weight:bold;font-size:12px;margin-bottom:6px;color:${cfg.color};">${typeBadge}&lt;${tagName}&gt;${hiddenBadge}</div>`;
+    let html = `<div style="font-weight:bold;font-size:12px;margin-bottom:6px;color:${cfg.color};">${typeBadge}&lt;${escapeHtml(tagName)}&gt;${hiddenBadge}</div>`;
 
     if (elementId) {
-        html += `<div><span style="color:#89dceb;">id</span><span style="color:#585b70;">: </span><span style="color:#a6e3a1;">"${elementId}"</span></div>`;
+        html += `<div><span style="color:#89dceb;">id</span><span style="color:#585b70;">: </span><span style="color:#a6e3a1;">"${escapeHtml(elementId)}"</span></div>`;
     }
 
     for (const { key, value } of props) {
-        html += `<div><span style="color:#89dceb;">${key}</span><span style="color:#585b70;">: </span><span style="color:#a6e3a1;">${value}</span></div>`;
+        html += `<div><span style="color:#89dceb;">${escapeHtml(key)}</span><span style="color:#585b70;">: </span><span style="color:#a6e3a1;">${escapeHtml(value)}</span></div>`;
     }
 
     panel.innerHTML = html;

--- a/src/functions/helpers.js
+++ b/src/functions/helpers.js
@@ -156,7 +156,8 @@ export function getComponentDataValue(component) {
             // Special case for boolean values
             return component.formData?.simpleBinding;
         }
-        return component.formData?.simpleBinding || component.formData?.data;
+        // Use nullish coalescing so legitimate falsy values (0, "") from simpleBinding are not discarded.
+        return component.formData?.simpleBinding ?? component.formData?.data;
     }
 }
 /**

--- a/src/functions/helpers.test.js
+++ b/src/functions/helpers.test.js
@@ -244,6 +244,15 @@ describe("getComponentDataValue", () => {
     it("returns formData.data if simpleBinding not present", () => {
         expect(getComponentDataValue({ isChildComponent: false, formData: { data: "def" } })).toBe("def");
     });
+    it("returns numeric 0 from simpleBinding instead of falling through to data", () => {
+        expect(getComponentDataValue({ isChildComponent: false, formData: { simpleBinding: 0, data: "def" } })).toBe(0);
+    });
+    it("returns an empty-string simpleBinding instead of falling through to data", () => {
+        expect(getComponentDataValue({ isChildComponent: false, formData: { simpleBinding: "", data: "def" } })).toBe("");
+    });
+    it("returns a boolean false simpleBinding", () => {
+        expect(getComponentDataValue({ isChildComponent: false, formData: { simpleBinding: false, data: "def" } })).toBe(false);
+    });
 });
 
 describe("getComponentDataTitle", () => {

--- a/src/functions/stringHelpers.js
+++ b/src/functions/stringHelpers.js
@@ -1,0 +1,20 @@
+/**
+ * Escapes the HTML-special characters (`&`, `<`, `>`) so a value can be safely interpolated into HTML text content.
+ *
+ * @param {*} value - The value to escape (coerced to a string).
+ * @returns {string} The escaped string.
+ */
+export function escapeHtml(value) {
+    return String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}
+
+/**
+ * Escapes a value for safe use inside a double-quoted HTML attribute (everything {@link escapeHtml} handles, plus the
+ * double-quote that would otherwise close the attribute).
+ *
+ * @param {*} value - The value to escape (coerced to a string).
+ * @returns {string} The attribute-escaped string.
+ */
+export function escapeHtmlAttribute(value) {
+    return escapeHtml(value).replaceAll('"', "&quot;");
+}

--- a/src/functions/stringHelpers.test.js
+++ b/src/functions/stringHelpers.test.js
@@ -1,0 +1,20 @@
+import { escapeHtml, escapeHtmlAttribute } from "./stringHelpers";
+
+describe("escapeHtml", () => {
+    it("escapes &, < and >", () => {
+        expect(escapeHtml('<img src=x> & "q"')).toBe('&lt;img src=x&gt; &amp; "q"');
+    });
+    it("escapes & before < and > (no double-escaping)", () => {
+        expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+    });
+    it("coerces non-string input to a string", () => {
+        expect(escapeHtml(42)).toBe("42");
+        expect(escapeHtml(null)).toBe("null");
+    });
+});
+
+describe("escapeHtmlAttribute", () => {
+    it("escapes the double quote in addition to &, < and >", () => {
+        expect(escapeHtmlAttribute('a"b<c>')).toBe("a&quot;b&lt;c&gt;");
+    });
+});

--- a/src/functions/tableDataHelpers.js
+++ b/src/functions/tableDataHelpers.js
@@ -1,0 +1,63 @@
+// Global functions
+import { instantiateComponent } from "./componentHelpers.js";
+
+/**
+ * Sorts a shallow copy of the provided rows by a key, so the caller's array (often a reference into the
+ * form data) is never mutated.
+ *
+ * Values that fully parse as numbers are compared numerically; everything else is compared as strings.
+ * `Number` is used (not `parseFloat`) so partial matches like "12abc" are treated as strings rather than 12,
+ * and null/undefined are treated as empty strings. Shared by the table and matrix data components.
+ *
+ * @param {string} sortKey - The key on each row object to sort by.
+ * @param {string} direction - The sort direction, "asc" (default) or "desc".
+ * @param {Array<Object>} rows - The rows to sort.
+ * @returns {Array<Object>} A new, sorted array (the input is left untouched). Non-array input is returned as-is.
+ */
+export function sortRowsByKey(sortKey, direction, rows) {
+    if (!Array.isArray(rows)) {
+        return rows;
+    }
+    const directionFactor = direction === "desc" ? -1 : 1;
+    return [...rows].sort((a, b) => {
+        const aValue = a?.[sortKey];
+        const bValue = b?.[sortKey];
+
+        const aNumber = Number(aValue);
+        const bNumber = Number(bValue);
+        const aIsNumber = aValue !== null && aValue !== undefined && aValue !== "" && !Number.isNaN(aNumber);
+        const bIsNumber = bValue !== null && bValue !== undefined && bValue !== "" && !Number.isNaN(bNumber);
+
+        if (aIsNumber && bIsNumber) {
+            if (aNumber < bNumber) return -1 * directionFactor;
+            if (aNumber > bNumber) return 1 * directionFactor;
+            return 0;
+        }
+
+        // Fall back to string comparison, treating null/undefined as an empty string.
+        const aString = aValue === null || aValue === undefined ? "" : String(aValue);
+        const bString = bValue === null || bValue === undefined ? "" : String(bValue);
+        if (aString < bString) return -1 * directionFactor;
+        if (aString > bString) return 1 * directionFactor;
+        return 0;
+    });
+}
+
+/**
+ * Removes rows whose cells are all empty. A cell is considered empty when its instantiated component reports
+ * `isEmpty`. Shared by the table and matrix data components.
+ *
+ * @param {Array<Array<any>>} rows - An array of rows, where each row is an array of cell objects.
+ * @returns {Array<Array<any>>} A new array containing only the non-empty rows (empty array for non-array input).
+ */
+export function removeEmptyRows(rows) {
+    if (!Array.isArray(rows)) {
+        return [];
+    }
+    return rows
+        .map((row) => {
+            const notEmptyCells = row.filter((cell) => !instantiateComponent(cell)?.isEmpty);
+            return notEmptyCells.length > 0 ? row : null;
+        })
+        .filter((row) => row !== null);
+}

--- a/src/functions/tableDataHelpers.test.js
+++ b/src/functions/tableDataHelpers.test.js
@@ -1,0 +1,76 @@
+import { removeEmptyRows, sortRowsByKey } from "./tableDataHelpers";
+import { instantiateComponent } from "./componentHelpers.js";
+
+jest.mock("./componentHelpers.js", () => ({
+    instantiateComponent: jest.fn()
+}));
+
+describe("sortRowsByKey", () => {
+    it("sorts numeric string values ascending", () => {
+        const rows = [{ age: "12" }, { age: "2" }, { age: "10" }];
+        expect(sortRowsByKey("age", "asc", rows)).toEqual([{ age: "2" }, { age: "10" }, { age: "12" }]);
+    });
+
+    it("sorts numeric string values descending", () => {
+        const rows = [{ age: "12" }, { age: "2" }, { age: "10" }];
+        expect(sortRowsByKey("age", "desc", rows)).toEqual([{ age: "12" }, { age: "10" }, { age: "2" }]);
+    });
+
+    it("sorts string values", () => {
+        const rows = [{ name: "A" }, { name: "C" }, { name: "B" }];
+        expect(sortRowsByKey("name", "asc", rows)).toEqual([{ name: "A" }, { name: "B" }, { name: "C" }]);
+        expect(sortRowsByKey("name", "desc", rows)).toEqual([{ name: "C" }, { name: "B" }, { name: "A" }]);
+    });
+
+    it("does not mutate the input array", () => {
+        const rows = [{ age: "3" }, { age: "1" }, { age: "2" }];
+        const snapshot = [...rows];
+        sortRowsByKey("age", "asc", rows);
+        expect(rows).toEqual(snapshot);
+    });
+
+    it("treats partially-numeric strings as strings, not numbers", () => {
+        // "12abc" is not a full number, so it is compared as a string ("1" < "3"), unlike parseFloat which would yield 12.
+        const rows = [{ v: "3" }, { v: "12abc" }];
+        expect(sortRowsByKey("v", "asc", rows)).toEqual([{ v: "12abc" }, { v: "3" }]);
+    });
+
+    it("treats null/undefined values as empty strings", () => {
+        const rows = [{ v: "b" }, { v: null }, { v: undefined }];
+        const result = sortRowsByKey("v", "asc", rows);
+        expect(result[result.length - 1]).toEqual({ v: "b" });
+    });
+
+    it("returns non-array input unchanged", () => {
+        expect(sortRowsByKey("v", "asc", null)).toBeNull();
+        expect(sortRowsByKey("v", "asc", undefined)).toBeUndefined();
+    });
+});
+
+describe("removeEmptyRows", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        instantiateComponent.mockImplementation((cell) => ({ isEmpty: cell.isEmpty }));
+    });
+
+    it("removes rows where all cells are empty", () => {
+        const rows = [
+            [{ isEmpty: true }, { isEmpty: true }],
+            [{ isEmpty: false }, { isEmpty: true }],
+            [{ isEmpty: false }, { isEmpty: false }]
+        ];
+        const result = removeEmptyRows(rows);
+        expect(result).toHaveLength(2);
+        expect(result[0]).toEqual([{ isEmpty: false }, { isEmpty: true }]);
+    });
+
+    it("keeps a row with at least one non-empty cell intact", () => {
+        const rows = [[{ isEmpty: false }, { isEmpty: true }]];
+        expect(removeEmptyRows(rows)).toEqual(rows);
+    });
+
+    it("returns an empty array for non-array input", () => {
+        expect(removeEmptyRows(null)).toEqual([]);
+        expect(removeEmptyRows(undefined)).toEqual([]);
+    });
+});

--- a/src/functions/textResourceHelpers.js
+++ b/src/functions/textResourceHelpers.js
@@ -26,79 +26,47 @@ export const fetchTextResources = async (origin, org, app, language, fallbackLan
         );
     }
 
-    if (isNonEmptyString(language)) {
-        const textResourcesApiUrl = `${origin}/${org}/${app}/api/v1/texts/${language}`;
-        try {
-            const primaryResponse = await fetchWithTimeoutAndClientLogger(textResourcesApiUrl, {}, 5000, clientLogger, customFields);
-            if (primaryResponse.ok) {
-                const textResourcesData = await primaryResponse.json();
-                if (hasValue(textResourcesData)) {
-                    return textResourcesData;
-                }
-            } else {
-                clientLogger?.postLogData([
-                    {
-                        level: "Error",
-                        message: `Could not retrieve text resources for language '${language}' from URL '${textResourcesApiUrl}'. Response status: ${primaryResponse.status}.`,
-                        custom_fields: customFields
-                    }
-                ]);
-                console.error(
-                    `Could not retrieve text resources for language '${language}' from URL '${textResourcesApiUrl}'. Response status: ${primaryResponse.status}.`
-                );
-            }
-        } catch (error) {
-            clientLogger?.postLogData([
-                {
-                    level: "Error",
-                    message: `Network or parsing error while retrieving text resources for language '${language}' from URL '${textResourcesApiUrl}': ${error.message}`,
-                    custom_fields: customFields
-                }
-            ]);
-            console.error(
-                `Network or parsing error while retrieving text resources for language '${language}' from URL '${textResourcesApiUrl}':`,
-                error
-            );
-        }
-    } else if (isNonEmptyString(fallbackLanguage)) {
-        const fallbackTextResourcesApiUrl = `${origin}/${org}/${app}/api/v1/texts/${fallbackLanguage}`;
-        try {
-            const fallbackResponse = await fetchWithTimeoutAndClientLogger(fallbackTextResourcesApiUrl, {}, 5000, clientLogger, customFields);
-            if (fallbackResponse.ok) {
-                const fallbackTextResourcesData = await fallbackResponse.json();
-                if (hasValue(fallbackTextResourcesData)) {
-                    return fallbackTextResourcesData;
-                }
-            } else {
-                clientLogger?.postLogData([
-                    {
-                        level: "Error",
-                        message: `Could not retrieve text resources for the fallback language '${fallbackLanguage}' from URL '${fallbackTextResourcesApiUrl}'. Response status: ${fallbackResponse.status}.`,
-                        custom_fields: customFields
-                    }
-                ]);
-                console.error(
-                    `Could not retrieve text resources for the fallback language '${fallbackLanguage}' from URL '${fallbackTextResourcesApiUrl}'. Response status: ${fallbackResponse.status}.`
-                );
-            }
-        } catch (error) {
-            clientLogger?.postLogData([
-                {
-                    level: "Error",
-                    message: `Network or parsing error while retrieving text resources for the fallback language '${fallbackLanguage}' from URL '${fallbackTextResourcesApiUrl}': ${error.message}`,
-                    custom_fields: customFields
-                }
-            ]);
-            console.error(
-                `Network or parsing error while retrieving text resources for the fallback language '${fallbackLanguage}' from URL '${fallbackTextResourcesApiUrl}':`,
-                error
-            );
-        }
-    } else {
-        console.error("No valid fallback language provided; skipping fallback text resources fetch.");
+    if (!isNonEmptyString(language)) {
+        return null;
     }
 
-    return null;
+    // Attempt the fallback language when the primary fetch fails, as long as it is valid and different.
+    const canFallBack = isNonEmptyString(fallbackLanguage) && fallbackLanguage !== language;
+    const tryFallback = () => (canFallBack ? fetchTextResources(origin, org, app, fallbackLanguage, null, clientLogger, customFields) : null);
+
+    const textResourcesApiUrl = `${origin}/${org}/${app}/api/v1/texts/${language}`;
+    try {
+        const primaryResponse = await fetchWithTimeoutAndClientLogger(textResourcesApiUrl, {}, 5000, clientLogger, customFields);
+        if (primaryResponse.ok) {
+            const textResourcesData = await primaryResponse.json();
+            if (hasValue(textResourcesData)) {
+                return textResourcesData;
+            }
+            return tryFallback();
+        } else {
+            clientLogger?.postLogData([
+                {
+                    level: "Error",
+                    message: `Could not retrieve text resources for language '${language}' from URL '${textResourcesApiUrl}'. Response status: ${primaryResponse.status}.`,
+                    custom_fields: customFields
+                }
+            ]);
+            console.error(
+                `Could not retrieve text resources for language '${language}' from URL '${textResourcesApiUrl}'. Response status: ${primaryResponse.status}.`
+            );
+            return tryFallback();
+        }
+    } catch (error) {
+        clientLogger?.postLogData([
+            {
+                level: "Error",
+                message: `Network or parsing error while retrieving text resources for language '${language}' from URL '${textResourcesApiUrl}': ${error.message}`,
+                custom_fields: customFields
+            }
+        ]);
+        console.error(`Network or parsing error while retrieving text resources for language '${language}' from URL '${textResourcesApiUrl}':`, error);
+        return tryFallback();
+    }
 };
 
 /**

--- a/src/functions/textResourceHelpers.test.js
+++ b/src/functions/textResourceHelpers.test.js
@@ -1,0 +1,95 @@
+import { fetchTextResources } from "./textResourceHelpers";
+import { fetchWithTimeoutAndClientLogger } from "./clientLoggerHelpers";
+import { hasValue } from "@arkitektum/altinn-studio-custom-components-utils";
+
+jest.mock("./clientLoggerHelpers", () => ({
+    fetchWithTimeoutAndClientLogger: jest.fn()
+}));
+jest.mock("@arkitektum/altinn-studio-custom-components-utils", () => ({
+    hasValue: jest.fn()
+}));
+
+describe("fetchTextResources", () => {
+    const origin = "https://org.example";
+    const org = "org";
+    const app = "app";
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        // Realistic hasValue: null/undefined/"" and empty objects are "no value".
+        hasValue.mockImplementation((value) => {
+            if (value === undefined || value === null || value === "") return false;
+            if (typeof value === "object") return Object.keys(value).length > 0;
+            return true;
+        });
+    });
+
+    afterEach(() => {
+        console.error.mockRestore();
+    });
+
+    it("returns primary-language resources when the fetch succeeds", async () => {
+        const data = { key: "value" };
+        fetchWithTimeoutAndClientLogger.mockResolvedValueOnce({ ok: true, json: async () => data });
+
+        const result = await fetchTextResources(origin, org, app, "en", "nb");
+
+        expect(result).toBe(data);
+        expect(fetchWithTimeoutAndClientLogger).toHaveBeenCalledTimes(1);
+        expect(fetchWithTimeoutAndClientLogger.mock.calls[0][0]).toContain("/api/v1/texts/en");
+    });
+
+    it("falls back to the fallback language when the primary response is not ok", async () => {
+        const fallbackData = { key: "fallback" };
+        fetchWithTimeoutAndClientLogger
+            .mockResolvedValueOnce({ ok: false, status: 404 })
+            .mockResolvedValueOnce({ ok: true, json: async () => fallbackData });
+
+        const result = await fetchTextResources(origin, org, app, "en", "nb");
+
+        expect(result).toBe(fallbackData);
+        expect(fetchWithTimeoutAndClientLogger).toHaveBeenCalledTimes(2);
+        expect(fetchWithTimeoutAndClientLogger.mock.calls[1][0]).toContain("/api/v1/texts/nb");
+    });
+
+    it("falls back when the primary fetch throws", async () => {
+        const fallbackData = { key: "fallback" };
+        fetchWithTimeoutAndClientLogger
+            .mockRejectedValueOnce(new Error("network error"))
+            .mockResolvedValueOnce({ ok: true, json: async () => fallbackData });
+
+        const result = await fetchTextResources(origin, org, app, "en", "nb");
+
+        expect(result).toBe(fallbackData);
+        expect(fetchWithTimeoutAndClientLogger).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back when the primary response is ok but empty", async () => {
+        const fallbackData = { key: "fallback" };
+        fetchWithTimeoutAndClientLogger
+            .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+            .mockResolvedValueOnce({ ok: true, json: async () => fallbackData });
+
+        const result = await fetchTextResources(origin, org, app, "en", "nb");
+
+        expect(result).toBe(fallbackData);
+        expect(fetchWithTimeoutAndClientLogger).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not fall back when the fallback language equals the primary language", async () => {
+        fetchWithTimeoutAndClientLogger.mockResolvedValueOnce({ ok: false, status: 500 });
+
+        const result = await fetchTextResources(origin, org, app, "nb", "nb");
+
+        expect(result).toBeNull();
+        expect(fetchWithTimeoutAndClientLogger).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null without fetching when the language is missing", async () => {
+        const result = await fetchTextResources(origin, org, app, "", "nb");
+
+        expect(result).toBeNull();
+        expect(fetchWithTimeoutAndClientLogger).not.toHaveBeenCalled();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@arkitektum/altinn-studio-custom-components-utils@npm:^1.4.15":
-  version: 1.4.15
-  resolution: "@arkitektum/altinn-studio-custom-components-utils@npm:1.4.15"
-  checksum: 10c0/6e67169ae36ed3a745f1c2487721b6702312210605315d53c3dadc0f00bdb680707406dbbebd8540be0d6b99825f75344d56ac44474524c1e3ffe3ec31b7a0ed
+"@arkitektum/altinn-studio-custom-components-utils@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@arkitektum/altinn-studio-custom-components-utils@npm:1.5.0"
+  checksum: 10c0/18cac65683b09b4f17475cd29f470b56a86b64d2a5f8a9a540f2241a6131efe4a88d07449caa6351828709b7d5876960b89d89e06b723fcf92dabbf31a826554
   languageName: node
   linkType: hard
 
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@arkitektum/altinn-studio-custom-components@workspace:."
   dependencies:
-    "@arkitektum/altinn-studio-custom-components-utils": "npm:^1.4.15"
+    "@arkitektum/altinn-studio-custom-components-utils": "npm:^1.5.0"
     "@arkitektum/client-logger": "npm:^1.2.1"
     "@babel/preset-env": "npm:^8.0.2"
     "@eslint/js": "npm:^10.0.1"
@@ -34,7 +34,7 @@ __metadata:
     jest-environment-jsdom: "npm:^30.4.1"
     jsdom: "npm:^29.1.1"
     mini-css-extract-plugin: "npm:^2.10.2"
-    prettier: "npm:3.9.4"
+    prettier: "npm:3.9.5"
     style-loader: "npm:^4.0.0"
     webpack: "npm:^5.108.4"
     webpack-cli: "npm:^7.2.1"
@@ -417,10 +417,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^8.0.0":
-  version: 8.0.2
-  resolution: "@babel/helper-validator-identifier@npm:8.0.2"
-  checksum: 10c0/629eda2a0a99442a1628bbef5f9fd8e26c1aa21ddbf02760d1c482b737932b1bb21fb1f89aacf9c3cf0642b481b810e39f94b8ae9aa44fc4f5516ebec6798b7b
+"@babel/helper-validator-identifier@npm:^8.0.0, @babel/helper-validator-identifier@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/helper-validator-identifier@npm:8.0.4"
+  checksum: 10c0/9d3c639a42b70613016fda026487a3b8056df918cb40221a48ef666a3bd2574475e315ee509c552baef4bef55a627ee8ea530e9af5b376512ab248c37aeab336
   languageName: node
   linkType: hard
 
@@ -470,14 +470,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/parser@npm:8.0.0"
+"@babel/parser@npm:^8.0.0, @babel/parser@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/parser@npm:8.0.4"
   dependencies:
-    "@babel/types": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/f10665bf3289f4bdc43bc58c482d6baa9fc4e306460d1bc57b059486dc9f23ed4463e746f62d721396466e2a2e0b32d856648b8c30dedbf6b69787b430f21e75
+  checksum: 10c0/b98ebc350e6583ccec0c59ab653e6c5967935826b8e03210a96e638a98b0c552587d4ca9cc44502964bac42463e2bab93ca1a6ac519279a25e190bd78f3ce513
   languageName: node
   linkType: hard
 
@@ -1461,17 +1461,17 @@ __metadata:
   linkType: hard
 
 "@babel/traverse@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/traverse@npm:8.0.0"
+  version: 8.0.4
+  resolution: "@babel/traverse@npm:8.0.4"
   dependencies:
     "@babel/code-frame": "npm:^8.0.0"
     "@babel/generator": "npm:^8.0.0"
     "@babel/helper-globals": "npm:^8.0.0"
-    "@babel/parser": "npm:^8.0.0"
+    "@babel/parser": "npm:^8.0.4"
     "@babel/template": "npm:^8.0.0"
-    "@babel/types": "npm:^8.0.0"
+    "@babel/types": "npm:^8.0.4"
     obug: "npm:^2.1.1"
-  checksum: 10c0/de5e5c144c72a2949d75ea8baf5dd2926a6410512397ac28692719df45e31e70e26415e10cacfe2c1c1dd73e7276c6a8fc832754c8b14202627d64e1aa1a9393
+  checksum: 10c0/0b7917580320c10027f660c97b754f883d11430bd4c9f877b1f57f424f31fd5a1e7260170be08f0197cbcf8abe65078063864e358cf024c90b64504837f3112e
   languageName: node
   linkType: hard
 
@@ -1485,13 +1485,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@babel/types@npm:8.0.0"
+"@babel/types@npm:^8.0.0, @babel/types@npm:^8.0.4":
+  version: 8.0.4
+  resolution: "@babel/types@npm:8.0.4"
   dependencies:
     "@babel/helper-string-parser": "npm:^8.0.0"
-    "@babel/helper-validator-identifier": "npm:^8.0.0"
-  checksum: 10c0/f4130b88818cf9fd0fb653dd35459f58794018416bc0cee0eccefd364c2d146ae90611ae3ae19d91c2f0bbd1e0e440840832baf9a3d5eb5fed077a52f0bcc001
+    "@babel/helper-validator-identifier": "npm:^8.0.4"
+  checksum: 10c0/c1549372b5544a797c9dd3cfba27c17e0c986cfadb1c4a99246743073e3be99c7c671572326be1739b313a2194e3bfe5a74b1bd213d80c4bbc2c520c8cb4ff1f
   languageName: node
   linkType: hard
 
@@ -2225,106 +2225,107 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-core@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-core@npm:4.57.8"
+"@jsonjoy.com/fs-core@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-core@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-node-builtins": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
     thingies: "npm:^2.5.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/09196a9662631df6eda00905f10f6581da9b0edd3e4999417d00c5a0f02ddd3bad3e01a2a60eea4290d2ff043c719a4ac2819fef98a914b99e6bd23b77b27141
+  checksum: 10c0/88c84d776ddc9114c7e2cc6df5ebac7f3c98547d31f4474257367de4765e4b440aea8f7dfc90145c394977e26566ac23303f5fabcfdfe6d0482d46cb2f675feb
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-fsa@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-fsa@npm:4.57.8"
+"@jsonjoy.com/fs-fsa@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-fsa@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
+    "@jsonjoy.com/fs-core": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
     thingies: "npm:^2.5.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/e23f43ad6afd6fd9ba5bb060adaafc9bad9f87341cf89a5b427f6a28a1a146487426b7c3b8be9f4d44730f9cab487d7d511e973a48e01c2bc54fa1ff4da8e582
+  checksum: 10c0/e97d78a9a9d793c63874e53d25e09cd6460bb2a4b357b22607625a25cfdb4f04a3bc07102dc640a4881b6f3411e613f18e9615b8aa95a60780d63adbe8e8e7bd
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-builtins@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-node-builtins@npm:4.57.8"
+"@jsonjoy.com/fs-node-builtins@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-node-builtins@npm:4.64.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/3c2de9f76b100db10e179daf346a73a4c271cc01c363b082cf6c7a034c53eb918e265520b1df1d4fbec7c1201592edf5a9111408576bf509776700a8f4327642
+  checksum: 10c0/9b4f6bb4c68ec51dea2fc12d70042ff0465ba4ecda32135a04578fbe335b05072eadf33b9cbaaa8e3203efcd935723a18fe3d9306eda606d3d70e306c0201b90
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-to-fsa@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-node-to-fsa@npm:4.57.8"
+"@jsonjoy.com/fs-node-to-fsa@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-node-to-fsa@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-fsa": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
+    "@jsonjoy.com/fs-fsa": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/d147707ae84b3f774afd108d2a7d6ee867a78b15a94f0ce5da5442056939f44103065f75694c37871440f5fbb15fa65a6c8e238e38365d8de9d4898d42e0edca
+  checksum: 10c0/49d859d80a2d38f33fcbb93ed225132032456eb2c5d2548105a314c2a517f5dfaf0c54fee80964e1b5acda57ca655f94bbd44efe5ad857d54e233aab71eb3cf0
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node-utils@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-node-utils@npm:4.57.8"
+"@jsonjoy.com/fs-node-utils@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-node-utils@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-node-builtins": "npm:4.57.8"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.64.0"
+    glob-to-regex.js: "npm:^1.0.1"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/80fee8af463dce150d0093fa8d935c2f7954caff5ed3031d2ec3263fce9077cb915152c6757bebf9a9a3a3eb909c4ee458ace57d2efa671d8ac31d59bc391a50
+  checksum: 10c0/1375cd6036c8c2d8d7264527f6eb6adeb1ced15704b97f0d73043dfc0f238bef2e8f4f3d010ca39b32bf9bb513a8e20aeb41b3c61efc1e9ac55eea386726e11a
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-node@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-node@npm:4.57.8"
+"@jsonjoy.com/fs-node@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-node@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
-    "@jsonjoy.com/fs-print": "npm:4.57.8"
-    "@jsonjoy.com/fs-snapshot": "npm:4.57.8"
+    "@jsonjoy.com/fs-core": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
+    "@jsonjoy.com/fs-print": "npm:4.64.0"
+    "@jsonjoy.com/fs-snapshot": "npm:4.64.0"
     glob-to-regex.js: "npm:^1.0.0"
     thingies: "npm:^2.5.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/1a4d2ce2d92584250df26c8873fb0f38bbbcb38b2ebe5125a416eb5d46e1be17db137c9fdeedba25c7bcd7b0dab3585c70f8d29a1a9c042d8f6fe467dc8f4974
+  checksum: 10c0/616574f539dfc24ff5cd364c6dc75022081fd652018c5133b25a3cf408368152e7c514a6956c8cd8b25997a8252254aa959784f631a320af463737244dac5350
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-print@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-print@npm:4.57.8"
+"@jsonjoy.com/fs-print@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-print@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
     tree-dump: "npm:^1.1.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/4b6e860eeb7a6c7d52b715b18877747bfd97f5e3e10dbc912a671a6ffb313e1a77c38058918696f33f5fd2d888a271e0707b8914cfd4aabb8e652ec4ec7e56b1
+  checksum: 10c0/0fd60d555f0dcb5a39e6ed4609e49a03edc8315eb0ca1b81022c37687a1c348ded6df3628cb9de4f6dec9c8bf9d647ad2ec9fe4f23a761936841cb6aa2489379
   languageName: node
   linkType: hard
 
-"@jsonjoy.com/fs-snapshot@npm:4.57.8":
-  version: 4.57.8
-  resolution: "@jsonjoy.com/fs-snapshot@npm:4.57.8"
+"@jsonjoy.com/fs-snapshot@npm:4.64.0":
+  version: 4.64.0
+  resolution: "@jsonjoy.com/fs-snapshot@npm:4.64.0"
   dependencies:
     "@jsonjoy.com/buffers": "npm:^17.65.0"
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
     "@jsonjoy.com/json-pack": "npm:^17.65.0"
     "@jsonjoy.com/util": "npm:^17.65.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/d2e6bd16b2b2c2d510949573a134284c06c57e3ae9b91ca59c3b1e694ccf66723b7ae0b726eabe2e436ff81a0032fe7e27935a163914ea11af9119fc2cc1c837
+  checksum: 10c0/caece02d0df3fe375b05112df6c1be34a3aa354a4960aeeaffaf3d6a8e840998d74f3fae85176ee4acbe37307f137c95cd035a5748903e85efb6b71bc3c19df5
   languageName: node
   linkType: hard
 
@@ -2606,9 +2607,9 @@ __metadata:
   linkType: hard
 
 "@sinclair/typebox@npm:^0.34.0":
-  version: 0.34.49
-  resolution: "@sinclair/typebox@npm:0.34.49"
-  checksum: 10c0/16b7d87f039a49b68c10bb4cdcae2ce5242b2472228851fd6483731616aba4ef977690aa517b230a8d20da8185bb416eb34e326f30568b3963c1cf26b05d1ad8
+  version: 0.34.50
+  resolution: "@sinclair/typebox@npm:0.34.50"
+  checksum: 10c0/e0ceda245b9b1ba2431df4f77d48a01bc291374411a98a6a6b2d8635204eec2bef986d09353eeb82e20229762123820d443239592087221984ddf75c842bfc83
   languageName: node
   linkType: hard
 
@@ -2733,14 +2734,14 @@ __metadata:
   linkType: hard
 
 "@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:^5.0.0, @types/express-serve-static-core@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@types/express-serve-static-core@npm:5.1.1"
+  version: 5.1.2
+  resolution: "@types/express-serve-static-core@npm:5.1.2"
   dependencies:
     "@types/node": "npm:*"
     "@types/qs": "npm:*"
     "@types/range-parser": "npm:*"
     "@types/send": "npm:*"
-  checksum: 10c0/ee88216e114368ef06bcafeceb74a7e8671b90900fb0ab1d49ff41542c3a344231ef0d922bf63daa79f0585f3eebe2ce5ec7f83facc581eff8bcdb136a225ef3
+  checksum: 10c0/0114a6d2e34d195ea3f547e9f599b400ebf445979ffc52f631f6e6ff2f77c8f9780da0cbaec8fd0b0b44739a35c717749e2f33b23743f9a7dea7238c8eadca0f
   languageName: node
   linkType: hard
 
@@ -2820,11 +2821,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 26.1.0
-  resolution: "@types/node@npm:26.1.0"
+  version: 26.1.1
+  resolution: "@types/node@npm:26.1.1"
   dependencies:
     undici-types: "npm:~8.3.0"
-  checksum: 10c0/61c22ad1ef215e24138cb8b7368fb68bab9de4c123b3f23d411749b015ba1b7d22f878ad54add26a0b69068d7e07c04af665069d8571b6c6c3b9b2fb73b7bd91
+  checksum: 10c0/25ac5093195736dd074d5027adbba85617bc951d5a41506ebd3b9073048acb7233613f3822d5f9b9447f9c0841c91f6387c46283916767e3ef79f23917452c46
   languageName: node
   linkType: hard
 
@@ -2910,9 +2911,9 @@ __metadata:
   linkType: hard
 
 "@ungap/structured-clone@npm:^1.3.0":
-  version: 1.3.2
-  resolution: "@ungap/structured-clone@npm:1.3.2"
-  checksum: 10c0/4d76bb376ec3e15f38bdffe045377807c79057daf54ae17eeb977c5b95efddd2d726b38c15aeb5d5c1a45c64ad03aa7e8b1a6dc67895480cba536ffd1c7a06ec
+  version: 1.3.3
+  resolution: "@ungap/structured-clone@npm:1.3.3"
+  checksum: 10c0/b199e280ee06e9c447e0ccd38df60a65c2b2c13d3c77af50b1e6d77230aee1ea7da309d7b80c5a4850c8e22e4eee9e4b2813c6a33f8c360560d7f2e99a9f6e8f
   languageName: node
   linkType: hard
 
@@ -3593,12 +3594,12 @@ __metadata:
   linkType: hard
 
 "bonjour-service@npm:^1.3.0":
-  version: 1.4.2
-  resolution: "bonjour-service@npm:1.4.2"
+  version: 1.4.3
+  resolution: "bonjour-service@npm:1.4.3"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     multicast-dns: "npm:^7.2.5"
-  checksum: 10c0/322315c8bc5faf7327d4076a452a12816ebfd5af7fd15b53253ea4d19140a31e8ae5f6aece428beae6f718ce41b1fca181f34e7e7b6eabe479d66455649cb00f
+  checksum: 10c0/6e6ce8172b76f77667d87db07dfa911940270f2ea4b5fb132b740904c9c95b43d432276648f79a1b6935770aa3686b369e58bd9bf2845f8c4f8f8d3fd7b52124
   languageName: node
   linkType: hard
 
@@ -3610,21 +3611,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
@@ -3764,9 +3765,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001800":
-  version: 1.0.30001802
-  resolution: "caniuse-lite@npm:1.0.30001802"
-  checksum: 10c0/a78992c08e8c540a4048bfdb08a839e536ba757075531989dd9a648783e328ef2b17cd00fa6fe21f4bd74136d13ed53108050bc4fbbf3f56820a4119cd70a8d8
+  version: 1.0.30001803
+  resolution: "caniuse-lite@npm:1.0.30001803"
+  checksum: 10c0/71586e9c84633cf766b208448eb76f860ec6e3befffc626d1f004e1902da063a7ab96cc94d1f4b36c0324e12997b3325a726de3287edfec91d0df495627a1d43
   languageName: node
   linkType: hard
 
@@ -4545,9 +4546,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.387":
-  version: 1.5.387
-  resolution: "electron-to-chromium@npm:1.5.387"
-  checksum: 10c0/49ac2f2431f48da75fbd30e4daee2304927d208adcdf4847b84ecc196785e94b1f6f873c093b59e61d14e928873518d294dc94803f4f8707ad7113aafe8dadd4
+  version: 1.5.389
+  resolution: "electron-to-chromium@npm:1.5.389"
+  checksum: 10c0/3681a3245fef5dfc8d9cdee231e80f8fe4fd7a87713d3a29a21ae2ec0cb6995cf14f3b3fd9e3fa8b483256e28ba2fa1daa9f23e93911a3a7241cd8f5daee9665
   languageName: node
   linkType: hard
 
@@ -5422,9 +5423,9 @@ __metadata:
   linkType: hard
 
 "httpxy@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "httpxy@npm:0.5.4"
-  checksum: 10c0/03353a75a25ab408f2f9b2f250c0b729018e897f85a0562e3e4934c92c5996a0da5505debe94bec4d90b56fc6051ca05f2d9cc55d968fee7b062cba460b3d3de
+  version: 0.5.5
+  resolution: "httpxy@npm:0.5.5"
+  checksum: 10c0/7be52cbfbd4157b4ac3aa22124d06081e8ffc50a185622e43c0ce8229bbcd7411d016f4a364fecb694325ed312823efbf51c70fa8049563a8b6b617642914cd3
   languageName: node
   linkType: hard
 
@@ -6504,9 +6505,9 @@ __metadata:
   linkType: hard
 
 "lru-cache@npm:^11.0.0, lru-cache@npm:^11.3.5":
-  version: 11.5.1
-  resolution: "lru-cache@npm:11.5.1"
-  checksum: 10c0/7b341cea79a8efe9c6a6f20c8757a77eca5b25d7ff983ccf4e11e547b81f6787824baa1c84705251dff84ab4ffac85717ac354b9d02e465f86a9f8b166409979
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: 10c0/ece1ad731f5b655e85d67047d04bfc13823dc77aa61c5454924a9869ba600a0104e39cc33d726021feef812bc347ca34a5608a5eb1972a5dd0870b7ecd42c3f2
   languageName: node
   linkType: hard
 
@@ -6566,17 +6567,17 @@ __metadata:
   linkType: hard
 
 "memfs@npm:^4.56.10":
-  version: 4.57.8
-  resolution: "memfs@npm:4.57.8"
+  version: 4.64.0
+  resolution: "memfs@npm:4.64.0"
   dependencies:
-    "@jsonjoy.com/fs-core": "npm:4.57.8"
-    "@jsonjoy.com/fs-fsa": "npm:4.57.8"
-    "@jsonjoy.com/fs-node": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-builtins": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-to-fsa": "npm:4.57.8"
-    "@jsonjoy.com/fs-node-utils": "npm:4.57.8"
-    "@jsonjoy.com/fs-print": "npm:4.57.8"
-    "@jsonjoy.com/fs-snapshot": "npm:4.57.8"
+    "@jsonjoy.com/fs-core": "npm:4.64.0"
+    "@jsonjoy.com/fs-fsa": "npm:4.64.0"
+    "@jsonjoy.com/fs-node": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-builtins": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-to-fsa": "npm:4.64.0"
+    "@jsonjoy.com/fs-node-utils": "npm:4.64.0"
+    "@jsonjoy.com/fs-print": "npm:4.64.0"
+    "@jsonjoy.com/fs-snapshot": "npm:4.64.0"
     "@jsonjoy.com/json-pack": "npm:^1.11.0"
     "@jsonjoy.com/util": "npm:^1.9.0"
     glob-to-regex.js: "npm:^1.0.1"
@@ -6585,7 +6586,7 @@ __metadata:
     tslib: "npm:^2.0.0"
   peerDependencies:
     tslib: 2
-  checksum: 10c0/8adffa2dc787caccb4be8addf4ea90ea33e6c494c858059420715a88c1f6c864617db22b28f819dbd25b25377d5d38667dd27f296b1adabb814ead9bfb6c5381
+  checksum: 10c0/fe4b887b1709faeed6c42567cb3310c534b1c4eebae00be19a950eb1c2cbe010e014cd7aa4255ff1afc34ec62a105a28c7add93ad4c36ee8b219e8665c9ca1f8
   languageName: node
   linkType: hard
 
@@ -6872,9 +6873,9 @@ __metadata:
   linkType: hard
 
 "node-releases@npm:^2.0.50":
-  version: 2.0.50
-  resolution: "node-releases@npm:2.0.50"
-  checksum: 10c0/ac75ed433864114cfd9862034960bb4f49838343dc9fc31dc7d5be8189ce5f39510ad0bb3a697efe3193d50ab6921e7a3a6ce3aae2a6f8abe62719ffd40a4cac
+  version: 2.0.51
+  resolution: "node-releases@npm:2.0.51"
+  checksum: 10c0/6cf3fe1f9eabe02ce6de67e9db77b73edc9f5625003791e1f8f239f8e2a851450a5aeb1eff2cc43cfb26312e19b26bfe07626bf428479e6a76f56553fc6148da
   languageName: node
   linkType: hard
 
@@ -7614,12 +7615,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.9.4":
-  version: 3.9.4
-  resolution: "prettier@npm:3.9.4"
+"prettier@npm:3.9.5":
+  version: 3.9.5
+  resolution: "prettier@npm:3.9.5"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/dc6ec13d692745c6b7e7bf39beda9eb1b3b76c619118319bce393928c392264b1273337c75f80499695e165affefc7b3a9d2ebb18983af0a8f4dfbb2f45f6ff3
+  checksum: 10c0/0349dd9e6d8010965de6f69e6b6ee2484b8caf78c66675afced6c75ad60ff24c3a2a4f41153fb8adeaee4d8f539641b48cebc71d283cec4d146e9962126c5ceb
   languageName: node
   linkType: hard
 
@@ -8434,8 +8435,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.10.0, terser@npm:^5.31.1":
-  version: 5.48.0
-  resolution: "terser@npm:5.48.0"
+  version: 5.49.0
+  resolution: "terser@npm:5.49.0"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.15.0"
@@ -8443,7 +8444,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10c0/d6ee713ea09a2b83b461ccbf1b76bd673a5090b3076ec13db7edc6d6470ab940d21c87b8d1ad82523b7cf02d9be07393fcdd334bde8f589e9bc3804da6fc32d2
+  checksum: 10c0/c1f628a7a6226f7283db92ce43247306d612b80a60a075d97e1f5539a032beee05c87f889eacff2ffabd2fa9ac6bd1c147e5eb49c6546c9b174ed241d5f056a7
   languageName: node
   linkType: hard
 
@@ -8501,10 +8502,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tldts-core@npm:^7.4.6":
-  version: 7.4.6
-  resolution: "tldts-core@npm:7.4.6"
-  checksum: 10c0/1da796a3e2b743d80a348ad9a98144e3284e74bd352b2a74e1cdb744e0c70637c1558d9c0909f28c3cd503b60d1f7c9e937ddb7a1330d7c426e25bb04f0ad3fd
+"tldts-core@npm:^7.4.8":
+  version: 7.4.8
+  resolution: "tldts-core@npm:7.4.8"
+  checksum: 10c0/94edee2a06cb1929fae4a26045628b01dd865ee8e28661df29128228522fb8dcf29c2f68ffa7286ee41a2a2c98da3e6814dbf49a1f6509de3fe2c9448e0db1b7
   languageName: node
   linkType: hard
 
@@ -8520,13 +8521,13 @@ __metadata:
   linkType: hard
 
 "tldts@npm:^7.0.5":
-  version: 7.4.6
-  resolution: "tldts@npm:7.4.6"
+  version: 7.4.8
+  resolution: "tldts@npm:7.4.8"
   dependencies:
-    tldts-core: "npm:^7.4.6"
+    tldts-core: "npm:^7.4.8"
   bin:
     tldts: bin/cli.js
-  checksum: 10c0/5ef08812a8e4e16563b98e3d47010ad1f06c48fe353799f2d69e4ba72ee6987e766e3077f14153c2f36b03b2cab2414c4696aa9a939d8bc8eceb1784c2a1d13b
+  checksum: 10c0/438b379a43b105359311427b8ab9d73572244996b4f6dd1fbe9112bd274c308d4ffb33b6f644302e79c8bc60f2e2539463b00dd91ee1063b92d9fc8b10882b6c
   languageName: node
   linkType: hard
 
@@ -8563,11 +8564,11 @@ __metadata:
   linkType: hard
 
 "tough-cookie@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "tough-cookie@npm:6.0.1"
+  version: 6.0.2
+  resolution: "tough-cookie@npm:6.0.2"
   dependencies:
     tldts: "npm:^7.0.5"
-  checksum: 10c0/ec70bd6b1215efe4ed31a158f0be3e4c9088fcbd8620edc23a5860d4f3d85c757b77e274baaa700f7b25e409f4181552ed189603c2b2e1a9f88104da3a61a37d
+  checksum: 10c0/5ff521a476a3c540821352125a5d481c8d2fe16035de7e0efda4df120f290c95500a0e9b51ea0aa56343955be482e014c30f5ba73e04b93ba138e4e855cb9e89
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This branch consolidates repeated component-lifecycle and rendering logic behind shared helpers, fixes a batch of correctness and security issues surfaced during review, improves table/matrix accessibility, and adds regression tests.
There are no changes to the public component API (tag names, attributes, and component contracts are unchanged).

### Changes

- **Component rendering**
  - Added a `renderCustomComponent` lifecycle helper (hide-if-empty → render → DevTools overlay → optional feedback list) and migrated ~67 base/data/layout components onto it removing the duplicated `connectedCallback` boilerplate.
    Added an `alwaysHideWhenEmpty` option for components that hide whenever empty (regardless of `hideIfEmpty`).
  - Replaced the serialize-and-reparse pattern (`el.innerHTML = createCustomElement(...).outerHTML`) with direct `appendChild` across ~25 sites.
  - Extracted the shared table/matrix logic into `tableDataHelpers` (`sortRowsByKey`, `removeEmptyRows`), de-duplicating `CustomTableData` and `CustomMatrixData`.
  - Centralized HTML escaping in `stringHelpers` (`escapeHtml`, `escapeHtmlAttribute`).
- **Bug fixes**
  - Guard empty input in `formatDateTime` / `formatTime` / `formatMeterSquared`.
  - `getComponentDataValue` uses nullish coalescing so `0` / `""` bindings are not dropped.
  - Table/matrix `hasContent` keys off the rows, so all-empty tables honor `hideIfEmpty`.
  - `fetchTextResources` now falls back to the fallback language when the primary fetch fails.
  - Table/matrix sort no longer mutates the underlying form-data array (shallow copy), and the comparator was hardened (`Number()` instead of `parseFloat`, null/undefined handling).
- **Security**
  - `custom-field` renders values via `textContent` unless `enableLinks` is set.
  - `injectAnchorElements` escapes the URL token in both the `href` and link text.
  - The DevTools panel escapes interpolated component/prop values.
- **Accessibility**: `scope="col"` / `scope="row"` on table and matrix `<th>` cells.
- **Tests**: new unit tests for the render helper, string helpers, table-data helpers, text-resource fallback, and `custom-field` renderers, plus regression tests for the security/fetch fixes.
- **Dependencies**: bump `@arkitektum/altinn-studio-custom-components-utils`; Prettier formatting.

### Impact

- **Behavioral changes (bug fixes, user-visible)**
  - Empty date/time/area fields render blank instead of `"Ugyldig datoformat"` / `"undefined m²"`; an empty `time` field no longer throws during render.
  - Numeric `0` and empty-string field values now display instead of being treated as empty.
  - Tables/matrices whose rows are all empty now respect `hideIfEmpty` (hidden or empty-field text) instead of rendering an empty header row.
  - Text resources fall back to the fallback language when the primary language fetch fails (previously no text resources were loaded).
  - Sorting edge case: partly-numeric strings such as `"12abc"` now sort as strings, not as `12`.
- **Breaking changes**: none to the public API.
  Note that `custom-field` now treats values as plain text unless `enableLinks` is set.
  Any consumer that (unintentionally) relied on raw HTML in a field value will now see it escaped.
- **Security**: closes XSS vectors in field values, URL auto-linking, and the DevTools panel.
- **Performance**: removes ~25 DOM serialize-then-reparse round-trips; sorting no longer mutates the form-data array, avoiding subtle re-render side effects.
- **Dependency**: requires the bumped `@arkitektum/altinn-studio-custom-components-utils` version to be published/available.
