### PR TITLE
Feature/add support for multiple app layouts

### DIFF
--- a/public/scripts/statistics/componentUsageHelpers.js
+++ b/public/scripts/statistics/componentUsageHelpers.js
@@ -35,7 +35,13 @@ function handleSubComponentUsages(component, layoutInfo, usageInfo, groupedUsage
             collectComponentUsageTreeGrouped(
                 subComponent,
                 layoutInfo,
-                { tagName: component.tagName, id: usageInfo.id, appOwner: layoutInfo.appOwner, appName: layoutInfo.appName },
+                {
+                    tagName: component.tagName,
+                    id: usageInfo.id,
+                    appOwner: layoutInfo.appOwner,
+                    appName: layoutInfo.appName,
+                    layoutName: layoutInfo.layoutName
+                },
                 groupedUsage
             );
         }
@@ -60,6 +66,7 @@ function collectComponentUsageTreeGrouped(component, layoutInfo, parentInfo, gro
         id: explicitId === undefined ? component.id || null : explicitId,
         appOwner: layoutInfo.appOwner,
         appName: layoutInfo.appName,
+        layoutName: layoutInfo.layoutName,
         parent: parentInfo
     };
     addUsageToGroup(tagName, usageInfo, groupedUsage);
@@ -75,7 +82,7 @@ function collectComponentUsageTreeGrouped(component, layoutInfo, parentInfo, gro
 export function getComponentUsageTreeForAllLayouts(displayLayouts) {
     const groupedUsage = {};
     for (const layout of displayLayouts) {
-        const layoutInfo = { appOwner: layout.appOwner, appName: layout.appName };
+        const layoutInfo = { appOwner: layout.appOwner, appName: layout.appName, layoutName: layout.layoutName };
         const componentsInLayout = Array.isArray(layout?.layout?.data?.layout) ? layout.layout.data.layout : null;
         if (!componentsInLayout) continue;
         for (const component of componentsInLayout) {

--- a/public/scripts/statistics/componentUsageRenderers.js
+++ b/public/scripts/statistics/componentUsageRenderers.js
@@ -15,7 +15,47 @@ function getAppUsageCountForComponent(component) {
 }
 
 /**
- * Get the direct usages of a component, grouped by unique apps.
+ * Groups a list of usages by unique app, and within each app by the display layout the usage was found in.
+ * Only usages matching the provided predicate are included.
+ * @param {Array} usages - The usages to group.
+ * @param {Function} predicate - A function returning true for usages that should be included.
+ * @returns {Array} - An array of objects like { appOwner, appName, layouts: [{ layoutName, usages: [] }] }.
+ */
+function groupUsagesByAppAndLayout(usages, predicate) {
+    if (!Array.isArray(usages)) {
+        return [];
+    }
+    const appUsageMap = {};
+    usages.forEach((usage) => {
+        if (!predicate(usage)) {
+            return;
+        }
+        const appKey = `${usage.appOwner}-${usage.appName}`;
+        if (!appUsageMap[appKey]) {
+            appUsageMap[appKey] = {
+                appOwner: usage.appOwner,
+                appName: usage.appName,
+                layouts: {}
+            };
+        }
+        const layoutKey = usage.layoutName ?? "";
+        if (!appUsageMap[appKey].layouts[layoutKey]) {
+            appUsageMap[appKey].layouts[layoutKey] = {
+                layoutName: usage.layoutName,
+                usages: []
+            };
+        }
+        appUsageMap[appKey].layouts[layoutKey].usages.push(usage);
+    });
+    return Object.values(appUsageMap).map((app) => ({
+        appOwner: app.appOwner,
+        appName: app.appName,
+        layouts: Object.values(app.layouts)
+    }));
+}
+
+/**
+ * Get the direct usages of a component, grouped by unique apps and by display layout within each app.
  * A direct usage is identified by the presence of an id in the usage object.
  * If a component has no direct usages, return an empty array.
  * @param {Object} component - The component object containing usage information.
@@ -25,27 +65,11 @@ function getDirectComponentUsages(component) {
     if (!component?.usages) {
         return [];
     }
-    // Filter usages that have an id, and group them by app owner and app name to get unique apps using the component
-    // Group them in a new array like this [{ appOwner: usage.appOwner, appName: usage.appName, usage: [usage] }]
-    const appUsageMap = {};
-    component.usages.forEach((usage) => {
-        if (usage?.id) {
-            const appKey = `${usage.appOwner}-${usage.appName}`;
-            if (!appUsageMap[appKey]) {
-                appUsageMap[appKey] = {
-                    appOwner: usage.appOwner,
-                    appName: usage.appName,
-                    usages: []
-                };
-            }
-            appUsageMap[appKey].usages.push(usage);
-        }
-    });
-    return Object.values(appUsageMap);
+    return groupUsagesByAppAndLayout(component.usages, (usage) => usage?.id);
 }
 
 /**
- * Get the indirect usages of a component, grouped by unique apps.
+ * Get the indirect usages of a component, grouped by unique apps and by display layout within each app.
  * An indirect usage is identified by the presence of a parent in the usage object.
  * If a component has no indirect usages, return an empty array.
  * @param {Object} component - The component object containing usage information.
@@ -55,21 +79,7 @@ function getIndirectComponentUsages(component) {
     if (!component?.usages) {
         return [];
     }
-    const componentUsageMap = {};
-    component.usages.forEach((usage) => {
-        if (usage?.parent) {
-            const appKey = `${usage.appOwner}-${usage.appName}`;
-            if (!componentUsageMap[appKey]) {
-                componentUsageMap[appKey] = {
-                    appOwner: usage.appOwner,
-                    appName: usage.appName,
-                    usages: []
-                };
-            }
-            componentUsageMap[appKey].usages.push(usage);
-        }
-    });
-    return Object.values(componentUsageMap);
+    return groupUsagesByAppAndLayout(component.usages, (usage) => usage?.parent);
 }
 
 /**
@@ -85,14 +95,67 @@ function renderAppUsingComponentListItem(appUsage) {
 }
 
 /**
- * Render a details element for an app using a component, including its usages.
- * @param {Object} appUsage - The app usage object containing app information and component usages.
- * @returns {HTMLElement} - The details element representing the app usage and its component usages.
+ * Count the total number of component usages across all display layouts of an app.
+ * @param {Array} layouts - The layouts array: [{ layoutName, usages }].
+ * @returns {number} - The total number of usages.
+ */
+function getTotalUsageCountForLayouts(layouts) {
+    if (!Array.isArray(layouts)) {
+        return 0;
+    }
+    return layouts.reduce((total, layout) => total + (layout?.usages?.length || 0), 0);
+}
+
+/**
+ * Render a details element for a single display layout within an app, listing the usages found in that layout.
+ * @param {Object} layoutUsage - The layout usage object: { layoutName, usages }.
+ * @param {Function} renderUsageItem - Function that renders a single usage list item.
+ * @returns {HTMLElement} - The details element representing the layout and its usages.
+ */
+function renderLayoutUsageDetailsListItem(layoutUsage, renderUsageItem) {
+    const layoutUsageListItemElement = document.createElement("details");
+    layoutUsageListItemElement.classList.add("layout-usage-details-list-item");
+    const layoutName = layoutUsage?.layoutName || "DisplayLayout";
+    const componentUsageNumber = layoutUsage?.usages?.length || 0;
+
+    const layoutUsageSummaryElement = document.createElement("summary");
+
+    const expandCollapseIconElement = document.createElement("span");
+    expandCollapseIconElement.classList.add("expand-collapse-icon");
+    expandCollapseIconElement.innerHTML = "▶";
+    layoutUsageSummaryElement.appendChild(expandCollapseIconElement);
+
+    const layoutUsageSummaryTitleElement = document.createElement("span");
+    layoutUsageSummaryTitleElement.classList.add("layout-usage-summary-title");
+    layoutUsageSummaryTitleElement.innerHTML = layoutName;
+
+    const layoutUsageSummaryCountElement = document.createElement("span");
+    layoutUsageSummaryCountElement.classList.add("layout-usage-summary-count");
+    layoutUsageSummaryCountElement.innerHTML = `Components: ${componentUsageNumber}`;
+
+    layoutUsageSummaryElement.appendChild(layoutUsageSummaryTitleElement);
+    layoutUsageSummaryElement.appendChild(layoutUsageSummaryCountElement);
+    layoutUsageListItemElement.appendChild(layoutUsageSummaryElement);
+
+    const layoutUsageListElement = document.createElement("ul");
+    layoutUsageListElement.classList.add("component-usage-list");
+    layoutUsage?.usages?.forEach((usage) => {
+        layoutUsageListElement.appendChild(renderUsageItem(usage));
+    });
+    layoutUsageListItemElement.appendChild(layoutUsageListElement);
+
+    return layoutUsageListItemElement;
+}
+
+/**
+ * Render a details element for an app using a component, grouped by the display layouts the component is used in.
+ * @param {Object} appUsage - The app usage object: { appOwner, appName, layouts: [{ layoutName, usages }] }.
+ * @returns {HTMLElement} - The details element representing the app usage and its layouts.
  */
 function renderAppUsageDetailsListItem(appUsage) {
     const appUsageListItemElement = document.createElement("details");
     const appName = appUsage ? `${appUsage?.appOwner}/${appUsage?.appName}` : "Unknown app";
-    const componentUsageNumber = appUsage?.usages?.length || 0;
+    const componentUsageNumber = getTotalUsageCountForLayouts(appUsage?.layouts);
     const appUsageSummaryElement = document.createElement("summary");
 
     const expandCollapseIconElement = document.createElement("span");
@@ -113,12 +176,12 @@ function renderAppUsageDetailsListItem(appUsage) {
 
     appUsageListItemElement.appendChild(appUsageSummaryElement);
 
-    const appUsageListElement = document.createElement("ul");
-    appUsageListElement.classList.add("component-usage-list");
-    appUsage?.usages?.forEach((usage) => {
-        appUsageListElement.appendChild(renderAppUsingComponentListItem(usage));
+    const appUsageLayoutListElement = document.createElement("div");
+    appUsageLayoutListElement.classList.add("layout-usage-details-list");
+    appUsage?.layouts?.forEach((layoutUsage) => {
+        appUsageLayoutListElement.appendChild(renderLayoutUsageDetailsListItem(layoutUsage, renderAppUsingComponentListItem));
     });
-    appUsageListItemElement.appendChild(appUsageListElement);
+    appUsageListItemElement.appendChild(appUsageLayoutListElement);
 
     return appUsageListItemElement;
 }
@@ -138,14 +201,14 @@ function renderComponentUsingComponentListItem(componentUsage) {
 }
 
 /**
- * Render a details element for a component using another component, including its usages.
- * @param {Object} componentUsage - The component usage object containing parent component information and its usages.
- * @returns {HTMLElement} - The details element representing the component usage and its usages.
+ * Render a details element for an app using a component indirectly, grouped by the display layouts it is used in.
+ * @param {Object} componentUsage - The app usage object: { appOwner, appName, layouts: [{ layoutName, usages }] }.
+ * @returns {HTMLElement} - The details element representing the app usage and its layouts.
  */
 function renderComponentUsageDetailsListItem(componentUsage) {
     const componentUsageListItemElement = document.createElement("details");
     const appName = componentUsage ? `${componentUsage?.appOwner}/${componentUsage?.appName}` : "Unknown app";
-    const componentUsageNumber = componentUsage?.usages?.length || 0;
+    const componentUsageNumber = getTotalUsageCountForLayouts(componentUsage?.layouts);
     const componentUsageSummaryElement = document.createElement("summary");
 
     const expandCollapseIconElement = document.createElement("span");
@@ -166,12 +229,12 @@ function renderComponentUsageDetailsListItem(componentUsage) {
 
     componentUsageListItemElement.appendChild(componentUsageSummaryElement);
 
-    const componentUsageListElement = document.createElement("ul");
-    componentUsageListElement.classList.add("component-usage-list");
-    componentUsage?.usages?.forEach((usage) => {
-        componentUsageListElement.appendChild(renderComponentUsingComponentListItem(usage));
+    const componentUsageLayoutListElement = document.createElement("div");
+    componentUsageLayoutListElement.classList.add("layout-usage-details-list");
+    componentUsage?.layouts?.forEach((layoutUsage) => {
+        componentUsageLayoutListElement.appendChild(renderLayoutUsageDetailsListItem(layoutUsage, renderComponentUsingComponentListItem));
     });
-    componentUsageListItemElement.appendChild(componentUsageListElement);
+    componentUsageListItemElement.appendChild(componentUsageLayoutListElement);
 
     return componentUsageListItemElement;
 }

--- a/public/scripts/statistics/componentUsageRenderers.test.js
+++ b/public/scripts/statistics/componentUsageRenderers.test.js
@@ -1,0 +1,51 @@
+import { renderComponentUsageListItem } from "./componentUsageRenderers";
+
+describe("renderComponentUsageListItem", () => {
+    it("groups direct usages by app and by display layout", () => {
+        const component = {
+            tagName: "custom-field-data",
+            usages: [
+                { tagName: "custom-field-data", id: "c1", appOwner: "o", appName: "a", layoutName: "DisplayLayout" },
+                { tagName: "custom-field-data", id: "c2", appOwner: "o", appName: "a", layoutName: "SvarSkjema" },
+                { tagName: "custom-field-data", id: "c3", appOwner: "o", appName: "a", layoutName: "SvarSkjema" }
+            ]
+        };
+        const element = renderComponentUsageListItem(component);
+
+        // Apps count is based on unique apps.
+        expect(element.querySelector(".app-usage").textContent).toContain("Apps: 1");
+
+        // Direct usage: one app node...
+        const appTitles = element.querySelectorAll(".app-usage-details-list .app-usage-summary-title");
+        expect(appTitles.length).toBe(1);
+        expect(appTitles[0].textContent).toBe("o/a");
+
+        // ...with two display layout nodes beneath it.
+        const layoutTitles = element.querySelectorAll(".app-usage-details-list .layout-usage-summary-title");
+        expect(Array.from(layoutTitles).map((node) => node.textContent)).toEqual(["DisplayLayout", "SvarSkjema"]);
+
+        // Component list items sum to the three direct usages.
+        expect(element.querySelectorAll(".app-using-component-list-item").length).toBe(3);
+    });
+
+    it("groups indirect usages by app and by display layout", () => {
+        const component = {
+            tagName: "custom-field-data",
+            usages: [
+                {
+                    tagName: "custom-field-data",
+                    appOwner: "o",
+                    appName: "a",
+                    layoutName: "DisplayLayout",
+                    parent: { tagName: "custom-group", id: "g1" }
+                }
+            ]
+        };
+        const element = renderComponentUsageListItem(component);
+
+        const layoutTitles = element.querySelectorAll(".component-usage-details-list .layout-usage-summary-title");
+        expect(layoutTitles.length).toBe(1);
+        expect(layoutTitles[0].textContent).toBe("DisplayLayout");
+        expect(element.querySelectorAll(".component-using-component-list-item").length).toBe(1);
+    });
+});

--- a/public/scripts/statistics/displayLayoutHelpers.js
+++ b/public/scripts/statistics/displayLayoutHelpers.js
@@ -1,0 +1,37 @@
+/**
+ * The layout name used for entries that do not declare a named display layout (e.g. standalone subforms).
+ */
+export const DEFAULT_LAYOUT_NAME = "DisplayLayout";
+
+/**
+ * Flattens app display layout entries into one entry per display layout.
+ *
+ * Each app entry may hold several named display layouts in its `displayLayouts` array. This helper expands those into
+ * individual per-layout entries, tagging each with its `layoutName`, so that the per-layout aggregators
+ * (component usage, resource usage) can process them uniformly. Standalone subform entries (which carry a single
+ * `layout` instead of a `displayLayouts` array) pass through as a single entry with a default layout name.
+ *
+ * @param {Array<Object>} displayLayouts - The array of app/subform display layout entries.
+ * @returns {Array<Object>} An array of per-layout entries, each with `appOwner`, `appName`, `dataType`, `layoutName`,
+ *   `layout`, and (where applicable) `isSubform`.
+ */
+export function flattenAppLayouts(displayLayouts) {
+    if (!Array.isArray(displayLayouts)) {
+        return [];
+    }
+    return displayLayouts.flatMap((entry) => {
+        // Standalone subform entries keep their single `layout` and are treated as a single display layout.
+        if (!Array.isArray(entry?.displayLayouts)) {
+            return [{ ...entry, layoutName: entry?.layoutName ?? DEFAULT_LAYOUT_NAME }];
+        }
+        return entry.displayLayouts.map((displayLayout) => ({
+            appOwner: entry.appOwner,
+            appName: entry.appName,
+            dataType: entry.dataType,
+            isSubform: entry.isSubform,
+            layoutName: displayLayout.name,
+            path: displayLayout.path,
+            layout: displayLayout.layout
+        }));
+    });
+}

--- a/public/scripts/statistics/displayLayoutHelpers.test.js
+++ b/public/scripts/statistics/displayLayoutHelpers.test.js
@@ -1,0 +1,35 @@
+import { DEFAULT_LAYOUT_NAME, flattenAppLayouts } from "./displayLayoutHelpers";
+
+describe("flattenAppLayouts", () => {
+    it("expands app entries into one entry per display layout", () => {
+        const displayLayouts = [
+            {
+                appOwner: "o",
+                appName: "a",
+                dataType: "DT",
+                displayLayouts: [
+                    { name: "DisplayLayout", path: "p1", layout: { data: { layout: [] } } },
+                    { name: "SvarSkjema", path: "p2", layout: { data: { layout: [] } } }
+                ]
+            }
+        ];
+        const result = flattenAppLayouts(displayLayouts);
+        expect(result.length).toBe(2);
+        expect(result.map((entry) => entry.layoutName)).toEqual(["DisplayLayout", "SvarSkjema"]);
+        expect(result[0]).toMatchObject({ appOwner: "o", appName: "a", dataType: "DT", path: "p1" });
+        expect(result[1].layout).toEqual({ data: { layout: [] } });
+    });
+
+    it("passes standalone subform entries through with a default layout name", () => {
+        const displayLayouts = [{ appOwner: "o", appName: "sub", dataType: "SubDT", isSubform: true, layout: { data: { layout: [] } } }];
+        const result = flattenAppLayouts(displayLayouts);
+        expect(result.length).toBe(1);
+        expect(result[0].layoutName).toBe(DEFAULT_LAYOUT_NAME);
+        expect(result[0].isSubform).toBe(true);
+    });
+
+    it("returns an empty array for non-array input", () => {
+        expect(flattenAppLayouts(undefined)).toEqual([]);
+        expect(flattenAppLayouts(null)).toEqual([]);
+    });
+});

--- a/public/scripts/statistics/index.js
+++ b/public/scripts/statistics/index.js
@@ -16,6 +16,7 @@ import {
 } from "../validators.js";
 import { renderAdminSidebar, renderSynchronizeButton } from "./renderers.js";
 import { getComponentUsageTreeForAllLayouts } from "./componentUsageHelpers.js";
+import { flattenAppLayouts } from "./displayLayoutHelpers.js";
 
 export function getDataFromLocalStorage() {
     const lastUpdated = getValueFromLocalStorage("lastUpdated");
@@ -76,8 +77,9 @@ globalThis.onload = async function () {
         exampleData,
         applicationMetadata
     });
-    const allTextResourceUsage = getAllTextResourceUsage(displayLayouts, multilingualAppResourceValues, multilingualDefaultTextResources);
-    const componentUsage = getComponentUsageTreeForAllLayouts(displayLayouts);
+    const flattenedLayouts = flattenAppLayouts(displayLayouts);
+    const allTextResourceUsage = getAllTextResourceUsage(flattenedLayouts, multilingualAppResourceValues, multilingualDefaultTextResources);
+    const componentUsage = getComponentUsageTreeForAllLayouts(flattenedLayouts);
     addDataToGlobalThis({
         defaultTextResources,
         multilingualDefaultTextResources,

--- a/public/scripts/statistics/index.js
+++ b/public/scripts/statistics/index.js
@@ -15,8 +15,8 @@ import {
     getUsageForResources
 } from "../validators.js";
 import { renderAdminSidebar, renderSynchronizeButton } from "./renderers.js";
-import { getComponentUsageTreeForAllLayouts } from "./componentUsageHelpers.js";
 import { flattenAppLayouts } from "./displayLayoutHelpers.js";
+import { getComponentUsageTreeForAllLayouts } from "./componentUsageHelpers.js";
 
 export function getDataFromLocalStorage() {
     const lastUpdated = getValueFromLocalStorage("lastUpdated");

--- a/public/scripts/statistics/renderers.js
+++ b/public/scripts/statistics/renderers.js
@@ -357,12 +357,65 @@ function renderSelectDisplayLayoutFilenameFilter(containerElement, displayLayout
 }
 
 /**
- * Renders a select dropdown to filter display layouts by form type (main form or subform).
- * The options in the dropdown are generated based on the `subForms` property of the provided `displayLayout` object.
- * When the selected form type changes, the display layouts page is re-rendered to show the components of the selected form type.
+ * The prefix used to encode a main display layout selection in the `formType` option (e.g. "layout:DisplayLayout").
+ * Subform selections use the subform's `appName` as the `formType` value.
+ */
+const LAYOUT_FORM_TYPE_PREFIX = "layout:";
+
+/**
+ * Resolves which main display layout a `formType` value refers to.
+ * Falls back to the first display layout when the `formType` is the legacy/default "main", empty, or unknown.
+ *
+ * @param {Object} displayLayout - The app display layout object, expected to have a `displayLayouts` array.
+ * @param {string} formType - The selected form type value.
+ * @returns {Object|null} The matching display layout ({ name, path, layout }), or null if none exist.
+ */
+function getDisplayLayoutByFormType(displayLayout, formType) {
+    const displayLayouts = displayLayout?.displayLayouts || [];
+    if (!displayLayouts.length) {
+        return null;
+    }
+    if (typeof formType === "string" && formType.startsWith(LAYOUT_FORM_TYPE_PREFIX)) {
+        const layoutName = formType.slice(LAYOUT_FORM_TYPE_PREFIX.length);
+        return displayLayouts.find((layout) => layout.name === layoutName) || null;
+    }
+    return displayLayouts[0];
+}
+
+/**
+ * Finds the subform that a `formType` value refers to, if any.
+ *
+ * @param {Object} displayLayout - The app display layout object, expected to have a `subForms` array.
+ * @param {string} formType - The selected form type value.
+ * @returns {Object|undefined} The matching subform, or undefined when the form type is a main display layout.
+ */
+function getSubFormByFormType(displayLayout, formType) {
+    return displayLayout?.subForms?.find((form) => form.appName === formType);
+}
+
+/**
+ * Normalizes a `formType` value to its canonical option value, so the correct dropdown option is selected.
+ * Subform selections keep their `appName`; main layout selections are normalized to "layout:<name>".
+ *
+ * @param {Object} displayLayout - The app display layout object.
+ * @param {string} formType - The selected form type value.
+ * @returns {string} The canonical form type value.
+ */
+function getSelectedFormType(displayLayout, formType) {
+    if (getSubFormByFormType(displayLayout, formType)) {
+        return formType;
+    }
+    const selectedLayout = getDisplayLayoutByFormType(displayLayout, formType);
+    return selectedLayout ? `${LAYOUT_FORM_TYPE_PREFIX}${selectedLayout.name}` : formType;
+}
+
+/**
+ * Renders a select dropdown to choose between an app's display layouts and its subforms.
+ * The options list each named display layout followed by each subform. The selector is only rendered when there
+ * is more than one thing to choose between. When the selection changes, the display layouts page is re-rendered.
  *
  * @param {HTMLElement} containerElement - The DOM element to which the filter form will be appended.
- * @param {Object} displayLayout - The current display layout object, expected to have a `subForms` property which is an array of subform objects.
+ * @param {Object} displayLayout - The current app display layout object, with `displayLayouts` and optional `subForms` arrays.
  * @param {Object} selectedOptions - An object containing the selected options for the display layouts page, including file names, form type, language, display layout app name, and display layout app owner.
  * @param {Array<Object>} appData - Array of application data objects, each expected to have a `dataType` and `data` property.
  * @param {Object} applicationMetadata - The metadata for the application, including information about the application's structure and configuration.
@@ -370,7 +423,10 @@ function renderSelectDisplayLayoutFilenameFilter(containerElement, displayLayout
  * @return {void}
  */
 function renderSelectFormTypeFilter(containerElement, displayLayout, selectedOptions, appData, applicationMetadata) {
-    if (!displayLayout?.subForms || displayLayout.subForms.length === 0) {
+    const displayLayouts = displayLayout?.displayLayouts || [];
+    const subForms = displayLayout?.subForms || [];
+    // Only offer the selector when there is more than one layout/subform to choose between.
+    if (displayLayouts.length + subForms.length <= 1) {
         return;
     }
 
@@ -383,16 +439,24 @@ function renderSelectFormTypeFilter(containerElement, displayLayout, selectedOpt
     const selectElement = document.createElement("select");
     selectElement.id = "select-form-type";
 
-    const mainFormOptionElement = document.createElement("option");
-    mainFormOptionElement.value = "main";
-    mainFormOptionElement.textContent = "Main form";
-    selectElement.appendChild(mainFormOptionElement);
+    const selectedFormType = getSelectedFormType(displayLayout, selectedOptions.formType);
 
-    displayLayout.subForms.forEach((subForm) => {
+    displayLayouts.forEach((layout) => {
+        const optionElement = document.createElement("option");
+        const value = `${LAYOUT_FORM_TYPE_PREFIX}${layout.name}`;
+        optionElement.value = value;
+        optionElement.textContent = layout.name;
+        if (value === selectedFormType) {
+            optionElement.selected = true;
+        }
+        selectElement.appendChild(optionElement);
+    });
+
+    subForms.forEach((subForm) => {
         const optionElement = document.createElement("option");
         optionElement.value = subForm.appName;
-        optionElement.textContent = subForm.appName;
-        if (subForm.appName === selectedOptions.formType) {
+        optionElement.textContent = `${subForm.appName} (subform)`;
+        if (subForm.appName === selectedFormType) {
             optionElement.selected = true;
         }
         selectElement.appendChild(optionElement);
@@ -402,14 +466,7 @@ function renderSelectFormTypeFilter(containerElement, displayLayout, selectedOpt
         const formType = event.target.value;
         const mainElement = document.getElementById("admin-main");
         mainElement.innerHTML = "";
-        if (formType === "main") {
-            await renderDisplayLayoutsPage(mainElement, appData, applicationMetadata, { ...selectedOptions, formType });
-        } else {
-            const subForm = displayLayout.subForms.find((form) => form.appName === formType);
-            if (subForm) {
-                await renderDisplayLayoutsPage(mainElement, appData, applicationMetadata, { ...selectedOptions, formType });
-            }
-        }
+        await renderDisplayLayoutsPage(mainElement, appData, applicationMetadata, { ...selectedOptions, formType });
     };
 
     formElement.appendChild(labelElement);
@@ -429,10 +486,7 @@ function renderSelectFormTypeFilter(containerElement, displayLayout, selectedOpt
  * @return {void}
  */
 function renderSelectSubFormDisplayLayoutFilenameFilter(containerElement, displayLayout, selectedOptions, appData, applicationMetadata) {
-    if (selectedOptions.formType === "main") {
-        return;
-    }
-    const subForm = displayLayout?.subForms?.find((form) => form.appName === selectedOptions.formType);
+    const subForm = getSubFormByFormType(displayLayout, selectedOptions.formType);
     if (!subForm) {
         return;
     }
@@ -509,10 +563,8 @@ export function getDisplayLayoutMainHeading() {
  * @returns {Object} An updated object mapping data types to the filenames that should be selected by default.
  */
 export function setDefaultSelectedFileNameForDisplayLayouts(displayLayout, appData, selectedOptions) {
-    const dataType =
-        selectedOptions.formType === "main"
-            ? displayLayout?.dataType
-            : displayLayout?.subForms?.find((form) => form.appName === selectedOptions.formType)?.dataType;
+    const selectedSubForm = getSubFormByFormType(displayLayout, selectedOptions.formType);
+    const dataType = selectedSubForm ? selectedSubForm.dataType : displayLayout?.dataType;
     if (!dataType) {
         return selectedOptions.fileNames;
     }
@@ -652,10 +704,10 @@ async function renderDisplayLayoutsPage(containerElement, appData, applicationMe
     renderSelectFormTypeFilter(containerElement, displayLayout, selectedOptions, appData, applicationMetadata);
     renderSelectSubFormDisplayLayoutFilenameFilter(containerElement, displayLayout, selectedOptions, appData, applicationMetadata);
 
-    const components =
-        selectedOptions.formType === "main"
-            ? displayLayout?.layout?.data?.layout || []
-            : displayLayout?.subForms?.find((form) => form.appName === selectedOptions.formType)?.layout?.data?.layout || [];
+    const selectedSubForm = getSubFormByFormType(displayLayout, selectedOptions.formType);
+    const components = selectedSubForm
+        ? selectedSubForm?.layout?.data?.layout || []
+        : getDisplayLayoutByFormType(displayLayout, selectedOptions.formType)?.layout?.data?.layout || [];
 
     const pageElement = document.createElement("div");
     pageElement.classList.add("page");
@@ -696,7 +748,7 @@ async function renderDisplayLayoutsPage(containerElement, appData, applicationMe
         .filter((attr) => attr !== undefined);
     appendChildren(codeResultsElement, resultsElements);
 
-    if (selectedOptions.formType === "main") {
+    if (!selectedSubForm) {
         const mainHeadingElement = getDisplayLayoutMainHeading();
         pageElement.appendChild(mainHeadingElement);
     }

--- a/public/scripts/statistics/renderers.test.js
+++ b/public/scripts/statistics/renderers.test.js
@@ -137,7 +137,15 @@ describe("renderSynchronizeButton", () => {
 describe("internal renderers functions", () => {
     beforeEach(() => {
         document.body.innerHTML = '<div id="admin-main"></div><div id="sidebar"></div>';
-        globalThis.displayLayouts = [{ appName: "app1", appOwner: "owner1", isSubform: false, layout: { data: { layout: [{ tagName: "div" }] } } }];
+        globalThis.displayLayouts = [
+            {
+                appName: "app1",
+                appOwner: "owner1",
+                displayLayouts: [
+                    { name: "DisplayLayout", path: "App/ui/form/layouts/DisplayLayout.json", layout: { data: { layout: [{ tagName: "div" }] } } }
+                ]
+            }
+        ];
         globalThis.allTextResourceUsage = [];
         globalThis.packageVersions = [
             {

--- a/public/scripts/textResourceUsageRenderers.js
+++ b/public/scripts/textResourceUsageRenderers.js
@@ -33,18 +33,73 @@ function renderComponentUsingResourceListItem(component) {
 }
 
 /**
+ * Counts the total number of components using a resource across all display layouts of an app.
+ *
+ * @param {Array<Object>} layouts - Per display layout usage, each containing a `componentsUsingResource` array.
+ * @returns {number} The total number of components using the resource.
+ */
+function getTotalComponentsForLayouts(layouts) {
+    if (!Array.isArray(layouts)) {
+        return 0;
+    }
+    return layouts.reduce((total, layout) => total + (layout?.componentsUsingResource?.length || 0), 0);
+}
+
+/**
+ * Creates a <details> element representing a single display layout's usage of a resource, including
+ * the layout name, the number of components using the resource, and a list of those components.
+ *
+ * @param {Object} layoutUsage - The usage details for a display layout: { layoutName, componentsUsingResource }.
+ * @returns {HTMLDetailsElement} The constructed <details> element representing the layout usage.
+ */
+function renderLayoutUsageDetailsListItem(layoutUsage) {
+    const layoutUsageListItemElement = document.createElement("details");
+    layoutUsageListItemElement.classList.add("layout-usage-details-list-item");
+    const layoutName = layoutUsage?.layoutName || "DisplayLayout";
+    const componentUsageNumber = layoutUsage?.componentsUsingResource?.length || 0;
+
+    const layoutUsageSummaryElement = document.createElement("summary");
+
+    const expandCollapseIconElement = document.createElement("span");
+    expandCollapseIconElement.classList.add("expand-collapse-icon");
+    expandCollapseIconElement.innerHTML = "▶";
+    layoutUsageSummaryElement.appendChild(expandCollapseIconElement);
+
+    const layoutUsageSummaryTitleElement = document.createElement("span");
+    layoutUsageSummaryTitleElement.classList.add("layout-usage-summary-title");
+    layoutUsageSummaryTitleElement.innerHTML = layoutName;
+
+    const layoutUsageSummaryCountElement = document.createElement("span");
+    layoutUsageSummaryCountElement.classList.add("layout-usage-summary-count");
+    layoutUsageSummaryCountElement.innerHTML = `Components: ${componentUsageNumber}`;
+
+    layoutUsageSummaryElement.appendChild(layoutUsageSummaryTitleElement);
+    layoutUsageSummaryElement.appendChild(layoutUsageSummaryCountElement);
+    layoutUsageListItemElement.appendChild(layoutUsageSummaryElement);
+
+    const componentUsageListElement = document.createElement("div");
+    componentUsageListElement.classList.add("component-usage-list");
+    layoutUsage?.componentsUsingResource?.forEach((component) => {
+        componentUsageListElement.appendChild(renderComponentUsingResourceListItem(component));
+    });
+    layoutUsageListItemElement.appendChild(componentUsageListElement);
+
+    return layoutUsageListItemElement;
+}
+
+/**
  * Creates a <details> element representing an application's usage details, including
- * the app name, the number of components using a resource, and a list of those components.
+ * the app name, the number of components using a resource, and its display layouts.
  *
  * @param {Object} appUsage - The usage details for an application.
  * @param {string} [appUsage.appName] - The name of the application.
- * @param {Array<Object>} [appUsage.componentsUsingResource] - Array of components using the resource.
+ * @param {Array<Object>} [appUsage.layouts] - Per display layout usage, each with a `layoutName` and `componentsUsingResource`.
  * @returns {HTMLElement} The constructed <details> element containing the app usage information.
  */
 function renderAppUsageDetailsListItem(appUsage) {
     const appUsageListItemElement = document.createElement("details");
     const appName = appUsage ? `${appUsage?.appOwner}/${appUsage?.appName}` : "Unknown app";
-    const componentUsageNumber = appUsage?.componentsUsingResource?.length || 0;
+    const componentUsageNumber = getTotalComponentsForLayouts(appUsage?.layouts);
     const appUsageSummaryElement = document.createElement("summary");
 
     const expandCollapseIconElement = document.createElement("span");
@@ -65,12 +120,12 @@ function renderAppUsageDetailsListItem(appUsage) {
 
     appUsageListItemElement.appendChild(appUsageSummaryElement);
 
-    const componentUsageListElement = document.createElement("div");
-    componentUsageListElement.classList.add("component-usage-list");
-    appUsage?.componentsUsingResource?.forEach((component) => {
-        componentUsageListElement.appendChild(renderComponentUsingResourceListItem(component));
+    const appUsageLayoutListElement = document.createElement("div");
+    appUsageLayoutListElement.classList.add("layout-usage-details-list");
+    appUsage?.layouts?.forEach((layoutUsage) => {
+        appUsageLayoutListElement.appendChild(renderLayoutUsageDetailsListItem(layoutUsage));
     });
-    appUsageListItemElement.appendChild(componentUsageListElement);
+    appUsageListItemElement.appendChild(appUsageLayoutListElement);
     return appUsageListItemElement;
 }
 
@@ -141,7 +196,7 @@ function getPresenceLabel(presence) {
  */
 export function renderDefaultTextResourceListItem(textResource, allTextResources) {
     const numberOfAppsUsingResource = textResource?.usage?.length;
-    const numberOfComponentsUsingResource = textResource?.usage?.reduce((total, app) => total + app?.componentsUsingResource?.length, 0) || 0;
+    const numberOfComponentsUsingResource = textResource?.usage?.reduce((total, app) => total + getTotalComponentsForLayouts(app?.layouts), 0) || 0;
     const resourcesWithSameValue = getResourcesWithSameValue(allTextResources, textResource);
 
     const listItemElement = document.createElement("details");

--- a/public/scripts/textResourceUsageRenderers.test.js
+++ b/public/scripts/textResourceUsageRenderers.test.js
@@ -13,9 +13,14 @@ describe("renderDefaultTextResourceListItem", () => {
                 {
                     appOwner: "owner",
                     appName: "app",
-                    componentsUsingResource: [
-                        { id: "comp1", tagName: "Input" },
-                        { id: "comp2", tagName: "Label" }
+                    layouts: [
+                        {
+                            layoutName: "DisplayLayout",
+                            componentsUsingResource: [
+                                { id: "comp1", tagName: "Input" },
+                                { id: "comp2", tagName: "Label" }
+                            ]
+                        }
                     ]
                 }
             ],

--- a/public/scripts/validators.js
+++ b/public/scripts/validators.js
@@ -378,16 +378,29 @@ export function getResourceUsageForLayout(layout, resource) {
  * @returns {Array<Object>} An array of objects, each containing:
  *   - {string} appOwner: The owner of the app.
  *   - {string} appName: The name of the app.
- *   - {Array} componentsUsingResource: List of components in the layout that use the specified resource.
+ *   - {Array} layouts: Per display layout usage, each containing a `layoutName` and the `componentsUsingResource` list.
  */
 export function getResourceUsage(layouts, resource) {
-    return layouts
-        .map((layout) => ({
-            appOwner: layout.appOwner,
-            appName: layout.appName,
-            componentsUsingResource: getResourceUsageForLayout(layout, resource)
-        }))
-        .filter((usage) => usage.componentsUsingResource.length > 0);
+    const appUsageMap = {};
+    layouts.forEach((layout) => {
+        const componentsUsingResource = getResourceUsageForLayout(layout, resource);
+        if (componentsUsingResource.length === 0) {
+            return;
+        }
+        const appKey = `${layout.appOwner}-${layout.appName}`;
+        if (!appUsageMap[appKey]) {
+            appUsageMap[appKey] = {
+                appOwner: layout.appOwner,
+                appName: layout.appName,
+                layouts: []
+            };
+        }
+        appUsageMap[appKey].layouts.push({
+            layoutName: layout.layoutName,
+            componentsUsingResource
+        });
+    });
+    return Object.values(appUsageMap);
 }
 
 /**
@@ -441,7 +454,7 @@ function getMissingResourceUsage(layouts, resource, appResourceValues) {
             const usageEntry = {
                 appOwner,
                 appName,
-                componentsUsingResource
+                layouts: [{ layoutName: layout.layoutName, componentsUsingResource }]
             };
             if (localAppResource) {
                 const values = localAppResource.values || {};

--- a/public/scripts/validators.test.js
+++ b/public/scripts/validators.test.js
@@ -101,13 +101,47 @@ describe("getResourceUsageForLayout", () => {
 describe("getResourceUsage", () => {
     it("returns usage across layouts", () => {
         const layouts = [
-            { appOwner: "o", appName: "a", layout: { data: { layout: [{ tagName: "X", type: "Custom", resourceBindings: { a: "id1" } }] } } },
-            { appOwner: "o", appName: "b", layout: { data: { layout: [{ tagName: "X", type: "Custom", resourceBindings: { a: "id2" } }] } } }
+            {
+                appOwner: "o",
+                appName: "a",
+                layoutName: "DisplayLayout",
+                layout: { data: { layout: [{ tagName: "X", type: "Custom", resourceBindings: { a: "id1" } }] } }
+            },
+            {
+                appOwner: "o",
+                appName: "b",
+                layoutName: "DisplayLayout",
+                layout: { data: { layout: [{ tagName: "X", type: "Custom", resourceBindings: { a: "id2" } }] } }
+            }
         ];
         const resource = { id: "id1" };
         const result = validators.getResourceUsage(layouts, resource);
         expect(result.length).toBe(1);
         expect(result[0].appName).toBe("a");
+        expect(result[0].layouts.length).toBe(1);
+        expect(result[0].layouts[0].layoutName).toBe("DisplayLayout");
+        expect(result[0].layouts[0].componentsUsingResource.length).toBe(1);
+    });
+
+    it("groups multiple display layouts of the same app under a single entry", () => {
+        const layouts = [
+            {
+                appOwner: "o",
+                appName: "a",
+                layoutName: "DisplayLayout",
+                layout: { data: { layout: [{ tagName: "X", type: "Custom", resourceBindings: { a: "id1" } }] } }
+            },
+            {
+                appOwner: "o",
+                appName: "a",
+                layoutName: "SvarSkjema",
+                layout: { data: { layout: [{ tagName: "Y", type: "Custom", resourceBindings: { a: "id1" } }] } }
+            }
+        ];
+        const resource = { id: "id1" };
+        const result = validators.getResourceUsage(layouts, resource);
+        expect(result.length).toBe(1);
+        expect(result[0].layouts.map((layout) => layout.layoutName)).toEqual(["DisplayLayout", "SvarSkjema"]);
     });
 });
 

--- a/public/styles/examples.css
+++ b/public/styles/examples.css
@@ -617,6 +617,11 @@
                     }
                     & .app-usage-details-list,
                     & .component-usage-details-list {
+                        /* Indent the display layout tier so it reads as nested inside the app,
+                           mirroring how the component list is indented inside each layout. */
+                        & .layout-usage-details-list {
+                            margin: 0 0 8px 16px;
+                        }
                         & details {
                             margin-bottom: 8px;
                             &:not(:last-child) {
@@ -632,13 +637,15 @@
                                     background-color: rgba(255, 255, 255, 0.05);
                                 }
                                 & .app-usage-summary-title,
-                                & .component-usage-summary-title {
+                                & .component-usage-summary-title,
+                                & .layout-usage-summary-title {
                                     font-weight: 600;
                                     color: var(--color-text-white);
                                     width: 100%;
                                 }
                                 & .app-usage-summary-count,
-                                & .component-usage-summary-count {
+                                & .component-usage-summary-count,
+                                & .layout-usage-summary-count {
                                     font-size: 14px;
                                     margin-left: 8px;
                                     font-weight: 300;


### PR DESCRIPTION
Support multiple display layouts per app

## Summary

Previously the statistics app assumed each app has a single main display layout (labelled "Main form"), optionally overridden by a layoutFile string. This PR lets an app expose multiple named display layouts, each with its own path and filename, and surfaces that new level throughout the statistics UI: App → display layout → component.

## What changed

### Data model

New flattenAppLayouts helper (displayLayoutHelpers.js) expands each app's displayLayouts array into one entry per layout, tagged with a layoutName. Standalone subforms pass through with a default name. The flattened list feeds the usage aggregators, while the nested per-app shape is kept for the display page.

### Component usage page

layoutName is threaded through the usage tree; usages are now grouped by app, then by display layout, adding a layout tier between the app and its components.

### Resource usage page

getResourceUsage / getMissingResourceUsage nest per-layout usage under each app; the renderer shows the same app → layout → component tier and counts components across layouts.

### Display layouts page

Layout selection is folded into the existing Form type filter, which now lists each named display layout followed by each subform. The hardcoded "Main form" option is gone (single-layout apps now show as DisplayLayout).

### Styling

The display-layout tier is indented inside each app item (matching how components nest inside a layout), and the layout usage count is aligned with the existing app/component count columns.
